### PR TITLE
Hide battery indicator on macOS builds

### DIFF
--- a/lib/screens/device_screen.dart
+++ b/lib/screens/device_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -211,6 +213,11 @@ class _DeviceScreenState extends State<DeviceScreen>
     MeshCoreConnector connector,
     BuildContext context,
   ) {
+    // Hide battery indicator on macOS as it shows incorrect values
+    if (Platform.isMacOS) {
+      return const SizedBox.shrink();
+    }
+
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final percent = connector.batteryPercent;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -81,7 +83,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             _buildInfoRow('Name', connector.deviceDisplayName),
             _buildInfoRow('ID', connector.deviceIdLabel),
             _buildInfoRow('Status', connector.isConnected ? 'Connected' : 'Disconnected'),
-            _buildBatteryInfoRow(connector),
+            if (!Platform.isMacOS) _buildBatteryInfoRow(connector),
             if (connector.selfName != null)
               _buildInfoRow('Node Name', connector.selfName!),
             if (connector.selfPublicKey != null)

--- a/lib/widgets/battery_indicator.dart
+++ b/lib/widgets/battery_indicator.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../connector/meshcore_connector.dart';
@@ -43,6 +45,11 @@ class _BatteryIndicatorState extends State<BatteryIndicator> {
 
   @override
   Widget build(BuildContext context) {
+    // Hide battery indicator on macOS as it shows incorrect values
+    if (Platform.isMacOS) {
+      return const SizedBox.shrink();
+    }
+
     final percent = widget.connector.batteryPercent;
     final millivolts = widget.connector.batteryMillivolts;
 


### PR DESCRIPTION
The battery indicator shows 0% on macOS builds, which is incorrect. This change hides the battery indicator on macOS to avoid displaying misleading information while maintaining the layout structure.

- BatteryIndicator widget returns SizedBox.shrink() on macOS
- Device screen battery indicator hidden on macOS
- Settings screen battery info row conditionally rendered (excluded on macOS)