### PR TITLE
Dev map manage repeater

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -17,6 +17,9 @@ import '../widgets/quick_switch_bar.dart';
 import 'channels_screen.dart';
 import 'chat_screen.dart';
 import 'contacts_screen.dart';
+//import 'repeater_hub_screen.dart';
+import '../widgets/repeater_login_dialog.dart';
+import 'repeater_hub_screen.dart';
 import 'settings_screen.dart';
 
 class MapScreen extends StatefulWidget {
@@ -549,6 +552,27 @@ class _MapScreenState extends State<MapScreen> {
     );
   }
 
+  void _showRepeaterLogin(BuildContext context, Contact repeater) {
+    showDialog(
+      context: context,
+      builder: (context) => RepeaterLoginDialog(
+        repeater: repeater,
+        onLogin: (password) {
+          // Navigate to repeater hub screen after successful login
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => RepeaterHubScreen(
+                repeater: repeater,
+                password: password,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
   void _showNodeInfo(BuildContext context, Contact contact) {
     showDialog(
       context: context,
@@ -592,6 +616,13 @@ class _MapScreenState extends State<MapScreen> {
                 );
               },
               child: const Text('Open Chat'),
+            ),
+            if(contact.type == advTypeRepeater)
+            TextButton(
+              onPressed: () {
+                _showRepeaterLogin(context, contact);
+              },
+              child: const Text('Manage Repeater'),
             ),
         ],
       ),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -17,7 +17,6 @@ import '../widgets/quick_switch_bar.dart';
 import 'channels_screen.dart';
 import 'chat_screen.dart';
 import 'contacts_screen.dart';
-//import 'repeater_hub_screen.dart';
 import '../widgets/repeater_login_dialog.dart';
 import 'repeater_hub_screen.dart';
 import 'settings_screen.dart';
@@ -617,13 +616,14 @@ class _MapScreenState extends State<MapScreen> {
               },
               child: const Text('Open Chat'),
             ),
-            if(contact.type == advTypeRepeater)
-            TextButton(
-              onPressed: () {
-                _showRepeaterLogin(context, contact);
-              },
-              child: const Text('Manage Repeater'),
-            ),
+            if (contact.type == advTypeRepeater)
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  _showRepeaterLogin(context, contact);
+                },
+                child: const Text('Manage Repeater'),
+              ),
         ],
       ),
     );


### PR DESCRIPTION
Add @wel97459 's changes along with some other fixes on his branch 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables managing repeater nodes directly from the map.
> 
> - Adds `RepeaterLoginDialog` flow and navigation to `RepeaterHubScreen` after successful login
> - Updates node info dialog to show `Manage Repeater` for `advTypeRepeater` contacts
> - Imports `repeater_login_dialog.dart` and `repeater_hub_screen.dart` in `map_screen.dart`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ba3f3ac49bf5c63448ffe5e57355d03989e818c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->