### PR TITLE
German translation V2

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -69,7 +69,7 @@
   },
   "scanner_stop": "Stopp",
   "scanner_scan": "Scannen",
-  "device_quickSwitch": "Schneller Umschalten",
+  "device_quickSwitch": "Schnelles Umschalten",
   "device_meshcore": "MeshCore",
   "settings_title": "Einstellungen",
   "settings_deviceInfo": "Geräteinformationen",
@@ -78,7 +78,7 @@
   "settings_nodeSettings": "Knoten-Einstellungen",
   "settings_nodeName": "Knotenname",
   "settings_nodeNameNotSet": "Nicht festgelegt",
-  "settings_nodeNameHint": "Gib den Knotenamen ein",
+  "settings_nodeNameHint": "Gebe den Knotenamen ein",
   "settings_nodeNameUpdated": "Name aktualisiert",
   "settings_radioSettings": "Funk Einstellungen",
   "settings_radioSettingsSubtitle": "Frequenz, Leistung, Verbreitungsfaktor",
@@ -90,17 +90,17 @@
   "settings_locationInvalid": "Ungültige Breiten- oder Längengrade.",
   "settings_latitude": "Breitengrad",
   "settings_longitude": "Längengrad",
-  "settings_privacyMode": "Privatschutzzustand",
-  "settings_privacyModeSubtitle": "Verstecken Sie Name/Ort in Anzeigen",
-  "settings_privacyModeToggle": "Aktivieren Sie den Datenschutzzustand, um Ihren Namen und Ihre Standortdaten in Anzeigen zu verbergen.",
-  "settings_privacyModeEnabled": "Privatschutzzustand aktiviert",
+  "settings_privacyMode": "Privatsphäreeinstellung",
+  "settings_privacyModeSubtitle": "Verstecken Sie Name/Ort in Ankündigungen",
+  "settings_privacyModeToggle": "Aktivieren Sie die Privatsphäreeinstellung, um Ihren Namen und Ihre Standortdaten in Ankündigungen zu verbergen.",
+  "settings_privacyModeEnabled": "Datenschutzmodus aktiviert",
   "settings_privacyModeDisabled": "Datenschutzmodus deaktiviert",
   "settings_actions": "Aktionen",
-  "settings_sendAdvertisement": "Senden Sie Anzeige",
-  "settings_sendAdvertisementSubtitle": "Sendungsstatus jetzt",
-  "settings_advertisementSent": "Anzeige gesendet",
-  "settings_syncTime": "Synchronisierungszeit",
-  "settings_syncTimeSubtitle": "Stelle die Gerätewielfalt auf die Uhrzeit des Telefons ein",
+  "settings_sendAdvertisement": "Sende eine Ankündigung",
+  "settings_sendAdvertisementSubtitle": "Sende Ankündigung",
+  "settings_advertisementSent": "Ankündigung gesendet",
+  "settings_syncTime": "Zeitsynchronisierung",
+  "settings_syncTimeSubtitle": "Stelle die Gerätezeit auf die Uhrzeit des Telefons ein",
   "settings_timeSynchronized": "Zeit synchronisiert",
   "settings_refreshContacts": "Kontakte aktualisieren",
   "settings_refreshContactsSubtitle": "Kontakte-Liste vom Gerät neu laden",
@@ -128,8 +128,8 @@
   "settings_infoStatus": "Status",
   "settings_infoBattery": "Akku",
   "settings_infoPublicKey": "Öffentlicher Schlüssel",
-  "settings_infoContactsCount": "Kontakte Anzahl",
-  "settings_infoChannelCount": "Kanalanzahl",
+  "settings_infoContactsCount": "Anzahl Kontakte",
+  "settings_infoChannelCount": "Anzahl Kanäle",
   "settings_presets": "Voreinstellungen",
   "settings_preset915Mhz": "915 MHz",
   "settings_preset868Mhz": "868 MHz",
@@ -139,11 +139,11 @@
   "settings_frequencyInvalid": "Ungültige Frequenz (300-2500 MHz)",
   "settings_bandwidth": "Bandbreite",
   "settings_spreadingFactor": "Verteilungsfaktor",
-  "settings_codingRate": "Programmierpauschale",
+  "settings_codingRate": "Kodierungsrate",
   "settings_txPower": "TX-Leistung (dBm)",
   "settings_txPowerHelper": "0 - 22",
   "settings_txPowerInvalid": "Ungültige TX-Leistung (0-22 dBm)",
-  "settings_longRange": "Langreich",
+  "settings_longRange": "Grosse Reichweite",
   "settings_fastSpeed": "Schnelle Geschwindigkeit",
   "settings_error": "Fehler: {message}",
   "@settings_error": {
@@ -157,7 +157,7 @@
   "appSettings_appearance": "Aussehen",
   "appSettings_theme": "Theme",
   "appSettings_themeSystem": "Systemstandard",
-  "appSettings_themeLight": "Helligkeit",
+  "appSettings_themeLight": "Hell",
   "appSettings_themeDark": "Dunkel",
   "appSettings_language": "Sprache",
   "appSettings_languageSystem": "Systemstandard",
@@ -176,19 +176,19 @@
   "appSettings_languageBg": "Български",
   "appSettings_notifications": "Benachrichtigungen",
   "appSettings_enableNotifications": "Benachrichtigungen aktivieren",
-  "appSettings_enableNotificationsSubtitle": "Erhalte Benachrichtigungen für Nachrichten und Anzeigen",
+  "appSettings_enableNotificationsSubtitle": "Erhalte Benachrichtigungen für Nachrichten und Ankündigungen",
   "appSettings_notificationPermissionDenied": "Erlaubnis zur Benachrichtigung verweigert",
   "appSettings_notificationsEnabled": "Benachrichtigungen aktiviert",
   "appSettings_notificationsDisabled": "Benachrichtigungen deaktiviert",
-  "appSettings_messageNotifications": "Nachrichtenbenachrichtigungen",
-  "appSettings_messageNotificationsSubtitle": "Zeige Benachrichtigung beim Empfang neuer Nachrichten",
-  "appSettings_channelMessageNotifications": "Kanal-Nachrichten-Benachrichtigungen",
+  "appSettings_messageNotifications": "Direktnachrichten Benachrichtigungen",
+  "appSettings_messageNotificationsSubtitle": "Zeige Benachrichtigung beim Empfang neuer Direktnachrichten",
+  "appSettings_channelMessageNotifications": "Kanalnachrichten Benachrichtigungen",
   "appSettings_channelMessageNotificationsSubtitle": "Zeige Benachrichtigung beim Empfangen von Kanalnachrichten",
-  "appSettings_advertisementNotifications": "Werbeanzeigenbenachrichtigungen",
+  "appSettings_advertisementNotifications": "Ankündigungsbenachrichtigungen",
   "appSettings_advertisementNotificationsSubtitle": "Zeige Benachrichtigung, wenn neue Knoten entdeckt werden.",
   "appSettings_messaging": "Nachrichten",
-  "appSettings_clearPathOnMaxRetry": "Klares Pfad bei Max Wiederholungsversuch",
-  "appSettings_clearPathOnMaxRetrySubtitle": "Zurücksetzen des Kontaktpfads nach 5 fehlgeschlagenen Sendeverboten",
+  "appSettings_clearPathOnMaxRetry": "Lösche Pfade bei Max Wiederholungsversuchen",
+  "appSettings_clearPathOnMaxRetrySubtitle": "Zurücksetzen der Kontaktpfade nach 5 fehlgeschlagenen Sendeabbrüchen",
   "appSettings_pathsWillBeCleared": "Die Pfade werden nach 5 fehlgeschlagenen Versuchen gelöscht.",
   "appSettings_pathsWillNotBeCleared": "Die Pfade werden nicht automatisch gelöscht.",
   "appSettings_autoRouteRotation": "Automatische Routenrotation",
@@ -226,10 +226,10 @@
       }
     }
   },
-  "appSettings_mapTimeFilter": "Kartent Zeitfilter",
+  "appSettings_mapTimeFilter": "Karten Zeitfilter",
   "appSettings_showNodesDiscoveredWithin": "Zeige Knoten, die innerhalb von:",
-  "appSettings_allTime": "Alle Zeit",
-  "appSettings_lastHour": "Letzter Stunde",
+  "appSettings_allTime": "Ganzer Zeitverlauf",
+  "appSettings_lastHour": "Letzte Stunde",
   "appSettings_last6Hours": "Letzte 6 Stunden",
   "appSettings_last24Hours": "Letzte 24 Stunden",
   "appSettings_lastWeek": "Letzte Woche",
@@ -252,13 +252,13 @@
   "appSettings_appDebugLoggingEnabled": "App-Debug-Protokollierung aktiviert",
   "appSettings_appDebugLoggingDisabled": "App-Debug-Protokollierung deaktiviert",
   "contacts_title": "Kontakte",
-  "contacts_noContacts": "No Contacts noch",
-  "contacts_contactsWillAppear": "Kontakte werden angezeigt, wenn Geräte Werbung machen.",
+  "contacts_noContacts": "Noch keine Kontakte vorhanden.",
+  "contacts_contactsWillAppear": "Kontakte werden angezeigt, wenn Geräte eine Ankündigung machen.",
   "contacts_searchContacts": "Suche Kontakte...",
-  "contacts_noUnreadContacts": "Keine ungeklärten Kontakte",
+  "contacts_noUnreadContacts": "Keine ungesehene Kontakte",
   "contacts_noContactsFound": "Keine Kontakte oder Gruppen gefunden.",
-  "contacts_deleteContact": "Löschen Sie Kontakt",
-  "contacts_removeConfirm": "Entfernen {contactName} aus den Kontakten?",
+  "contacts_deleteContact": "Lösche den Kontakt",
+  "contacts_removeConfirm": "{contactName} aus den Kontakten entfernen?",
   "@contacts_removeConfirm": {
     "placeholders": {
       "contactName": {
@@ -266,12 +266,12 @@
       }
     }
   },
-  "contacts_manageRepeater": "Wiederholung verwalten",
+  "contacts_manageRepeater": "Wiederholungen verwalten",
   "contacts_roomLogin": "Raum-Login",
-  "contacts_openChat": "Öffnen Sie Chat",
-  "contacts_editGroup": "Gruppen bearbeiten",
+  "contacts_openChat": "Öffne Chat",
+  "contacts_editGroup": "Gruppe bearbeiten",
   "contacts_deleteGroup": "Löschen Gruppe",
-  "contacts_deleteGroupConfirm": "Löschen Sie \"{groupName}\"?",
+  "contacts_deleteGroupConfirm": "Löschen von \"{groupName}\"?",
   "@contacts_deleteGroupConfirm": {
     "placeholders": {
       "groupName": {
@@ -293,8 +293,8 @@
   "contacts_filterContacts": "Filtert Kontakte...",
   "contacts_noContactsMatchFilter": "Keine Kontakte passen zu Ihrem Filter",
   "contacts_noMembers": "Keine Mitglieder",
-  "contacts_lastSeenNow": "Letztes Ansehen jetzt",
-  "contacts_lastSeenMinsAgo": "Letzte Sichtung {minutes} Minuten her.",
+  "contacts_lastSeenNow": "gerade gesehen",
+  "contacts_lastSeenMinsAgo": "Letzte Sichtung vor {minutes} Minuten.",
   "@contacts_lastSeenMinsAgo": {
     "placeholders": {
       "minutes": {
@@ -303,7 +303,7 @@
     }
   },
   "contacts_lastSeenHourAgo": "Letzte Sichtung vor 1 Stunde.",
-  "contacts_lastSeenHoursAgo": "Letzte Aktivität vor {hours} Stunden.",
+  "contacts_lastSeenHoursAgo": "Letzte Sichtung vor {hours} Stunden.",
   "@contacts_lastSeenHoursAgo": {
     "placeholders": {
       "hours": {
@@ -339,8 +339,8 @@
   "channels_publicChannel": "Öffentlicher Kanal",
   "channels_privateChannel": "Privater Kanal",
   "channels_editChannel": "Kanal bearbeiten",
-  "channels_deleteChannel": "Löschen Sie Kanal",
-  "channels_deleteChannelConfirm": "Löschen \"{name}\"? Dies kann nicht rückgängig gemacht werden.",
+  "channels_deleteChannel": "Lösche den Kanal",
+  "channels_deleteChannelConfirm": "Löschen von \"{name}\"? Dies kann nicht rückgängig gemacht werden.",
   "@channels_deleteChannelConfirm": {
     "placeholders": {
       "name": {
@@ -373,7 +373,7 @@
       }
     }
   },
-  "channels_editChannelTitle": "Bearbeiteten Kanal {index}",
+  "channels_editChannelTitle": "Bearbeiteter Kanal {index}",
   "@channels_editChannelTitle": {
     "placeholders": {
       "index": {
@@ -392,10 +392,10 @@
   },
   "channels_publicChannelAdded": "Öffentlicher Kanal hinzugefügt",
   "channels_sortBy": "Sortiere nach",
-  "channels_sortManual": "Manuelle",
+  "channels_sortManual": "Manuell",
   "channels_sortAZ": "A bis Z",
   "channels_sortLatestMessages": "Letzte Nachrichten",
-  "channels_sortUnread": "Unlescht",
+  "channels_sortUnread": "Ungelesen",
   "chat_noMessages": "Noch keine Nachrichten.",
   "chat_sendMessageToStart": "Eine Nachricht senden, um anzufangen.",
   "chat_originalMessageNotFound": "Originalmeldung nicht gefunden",
@@ -407,7 +407,7 @@
       }
     }
   },
-  "chat_replyTo": "Antworten Sie {name}",
+  "chat_replyTo": "Antwort an {name}",
   "@chat_replyTo": {
     "placeholders": {
       "name": {
@@ -436,7 +436,7 @@
   "chat_messageCopied": "Nachricht kopiert",
   "chat_messageDeleted": "Nachricht gelöscht",
   "chat_retryingMessage": "Versuche es erneut.",
-  "chat_retryCount": "Versuchen {current}/{max}",
+  "chat_retryCount": "Versuche {current}/{max}",
   "@chat_retryCount": {
     "placeholders": {
       "current": {
@@ -457,22 +457,22 @@
   "emojiCategoryObjects": "Objekte",
   "gifPicker_title": "Wähle ein GIF",
   "gifPicker_searchHint": "Suche nach GIFs...",
-  "gifPicker_poweredBy": "Angetrieben von GIPHY",
+  "gifPicker_poweredBy": "Bereitgestellt von GIPHY",
   "gifPicker_noGifsFound": "Keine GIFs gefunden",
-  "gifPicker_failedLoad": "GIF-Dateien konnten nicht geladen werden.",
+  "gifPicker_failedLoad": "GIF-Datei konnten nicht geladen werden.",
   "gifPicker_failedSearch": "Suche nach GIFs fehlgeschlagen",
   "gifPicker_noInternet": "Keine Internetverbindung",
   "debugLog_appTitle": "App-Debug-Protokoll",
   "debugLog_bleTitle": "BLE-Debug-Protokoll",
-  "debugLog_copyLog": "Kopieren Sie Protokoll",
-  "debugLog_clearLog": "Log löschen",
+  "debugLog_copyLog": "Kopieren des Protokolls",
+  "debugLog_clearLog": "Protokoll löschen",
   "debugLog_copied": "Debug-Protokoll kopiert",
   "debugLog_bleCopied": "BLE-Protokoll kopiert",
   "debugLog_noEntries": "No Debug-Protokolle noch verfügbar",
   "debugLog_enableInSettings": "Aktivieren Sie das App-Debug-Logging in den Einstellungen",
   "debugLog_frames": "Rahmen",
   "debugLog_rawLogRx": "Roh-Log-RX",
-  "debugLog_noBleActivity": "No BLE-Aktivität bisher",
+  "debugLog_noBleActivity": "Bisher keine BLE-Aktivität",
   "debugFrame_length": "Rahmenlänge: {count} Bytes",
   "@debugFrame_length": {
     "placeholders": {
@@ -539,12 +539,12 @@
   "chat_pathManagement": "Pfadverwaltung",
   "chat_routingMode": "Routenmodus",
   "chat_autoUseSavedPath": "Automatisch (gespeicherten Pfad verwenden)",
-  "chat_forceFloodMode": "Zwangsgelände-Modus erzwingen",
+  "chat_forceFloodMode": "Flut-Modus erzwingen",
   "chat_recentAckPaths": "Aktuelle ACK-Pfade (tasten, um zu verwenden):",
   "chat_pathHistoryFull": "Die Pfadhistorie ist voll. Entferne Einträge, um neue hinzuzufügen.",
-  "chat_hopSingular": "Springe",
-  "chat_hopPlural": "Hops",
-  "chat_hopsCount": "{count} {count, plural, =1{Hop} other{Hops}}",
+  "chat_hopSingular": "Sprung",
+  "chat_hopPlural": "Sprünge",
+  "chat_hopsCount": "{count} {count, plural, =1{Sprung} other{Sprünge}}",
   "@chat_hopsCount": {
     "placeholders": {
       "count": {
@@ -552,17 +552,17 @@
       }
     }
   },
-  "chat_successes": "Erfolgreiche",
+  "chat_successes": "Erfolgreich",
   "chat_removePath": "Pfad entfernen",
-  "chat_noPathHistoryYet": "Noe eine Pfadhistorie vorhanden.\nSende eine Nachricht, um Pfade zu entdecken.",
+  "chat_noPathHistoryYet": "Keine eine Pfadhistorie vorhanden.\nSende eine Nachricht, um Pfade zu entdecken.",
   "chat_pathActions": "Pfadaktionen:",
   "chat_setCustomPath": "Lege benutzerdefinierten Pfad fest",
-  "chat_setCustomPathSubtitle": "Manuelle Routenpfad festlegen",
-  "chat_clearPath": "Klares Pfad",
-  "chat_clearPathSubtitle": "Zwinge bei nächster Sendung eine erneute Entdeckung durch.",
-  "chat_pathCleared": "Pfad freigelegt. Nächste Nachricht wird Route neu entdecken.",
+  "chat_setCustomPathSubtitle": "Manuellen Routenpfad festlegen",
+  "chat_clearPath": "Pfad zurücksetzen",
+  "chat_clearPathSubtitle": "Setze Pfad zurück, erkenne neuen Pfad bei nächster Sendung.",
+  "chat_pathCleared": "Pfad zurückgesetzt. Nächste Nachricht wird Route neu entdecken.",
   "chat_floodModeSubtitle": "Verwende den Routingschalter in der App-Leiste",
-  "chat_floodModeEnabled": "Flutmodus aktiviert. Über den Routing-Icon in der App-Leiste wieder aktivieren.",
+  "chat_floodModeEnabled": "Flutmodus aktiviert.",
   "chat_fullPath": "Vollständiger Pfad",
   "chat_pathDetailsNotAvailable": "Die Pfaddetails sind noch nicht verfügbar. Versuchen Sie, eine Nachricht zu senden, um zu aktualisieren.",
   "chat_pathSetHops": "Pfad gesetzt: {hopCount} {hopCount, plural, =1{hop} other{hops}} - {status}",
@@ -576,15 +576,15 @@
       }
     }
   },
-  "chat_pathSavedLocally": "Gespeichert lokal. Mit Verbinden zum Synchronisieren.",
+  "chat_pathSavedLocally": "Lokal Gespeichert. Bitte Verbinden zum Synchronisieren.",
   "chat_pathDeviceConfirmed": "Gerät bestätigt.",
   "chat_pathDeviceNotConfirmed": "Gerät noch nicht bestätigt.",
-  "chat_type": "Gib ein",
+  "chat_type": "Gebe ein",
   "chat_path": "Pfad",
   "chat_publicKey": "Öffentlicher Schlüssel",
-  "chat_compressOutgoingMessages": "Komprimieren ausgehende Nachrichten",
-  "chat_floodForced": "Überschwemmung (erzwungen)",
-  "chat_directForced": "Direkt (gezwungen)",
+  "chat_compressOutgoingMessages": "Komprimieren ausgehender Nachrichten",
+  "chat_floodForced": "Geflutet (erzwungen)",
+  "chat_directForced": "Direkt (erzwungen)",
   "chat_hopsForced": "{count} Sprünge (erzwungen)",
   "@chat_hopsForced": {
     "placeholders": {
@@ -593,10 +593,10 @@
       }
     }
   },
-  "chat_floodAuto": "Überschwemmung (automatisch)",
+  "chat_floodAuto": "Geflutet (automatisch)",
   "chat_direct": "Direkt",
-  "chat_poiShared": "Gemeinsamer POI",
-  "chat_unread": "Unlescht: {count}",
+  "chat_poiShared": "Geteilter POI",
+  "chat_unread": "Ungelesen: {count}",
   "@chat_unread": {
     "placeholders": {
       "count": {
@@ -604,9 +604,9 @@
       }
     }
   },
-  "map_title": "Knotenkarte",
+  "map_title": "Karte",
   "map_noNodesWithLocation": "Keine Knoten mit Standortdaten",
-  "map_nodesNeedGps": "Knoten müssen ihre GPS-Koordinaten\nteilen,\num auf der Karte\nerscheinen.",
+  "map_nodesNeedGps": "Knoten müssen ihre GPS-Koordinaten teilen,\num auf der Karte zu erscheinen.",
   "map_nodesCount": "Knoten: {count}",
   "@map_nodesCount": {
     "placeholders": {
@@ -623,24 +623,24 @@
       }
     }
   },
-  "map_chat": "Chat",
-  "map_repeater": "Wiederholung",
+  "map_chat": "Benutzer",
+  "map_repeater": "Repeater",
   "map_room": "Raum",
   "map_sensor": "Sensor",
-  "map_pinDm": "Sperren (DM)",
-  "map_pinPrivate": "Privat-Pin",
-  "map_pinPublic": "Öffentliche Taste (PIN)",
+  "map_pinDm": "Pin (Kontakt)",
+  "map_pinPrivate": "Pin (Channel)",
+  "map_pinPublic": "Pin (Public)",
   "map_lastSeen": "Letzte Sichtung",
   "map_disconnectConfirm": "Sind Sie sicher, dass Sie sich von diesem Gerät trennen möchten?",
   "map_from": "Von",
   "map_source": "Quelle",
-  "map_flags": "Flaggen",
-  "map_shareMarkerHere": "Teilen Sie hier das Marker.",
-  "map_pinLabel": "Kennzeichnungslabel",
+  "map_flags": "Flags",
+  "map_shareMarkerHere": "Teilen Sie den Marker hier.",
+  "map_pinLabel": "Pin Name",
   "map_label": "Label",
   "map_pointOfInterest": "Punkt von Interesse",
   "map_sendToContact": "Senden an Kontakt",
-  "map_sendToChannel": "Senden Sie Kanal",
+  "map_sendToChannel": "Senden an Kanal",
   "map_noChannelsAvailable": "Keine Kanäle verfügbar",
   "map_publicLocationShare": "Öffentliche Standortfreigabe",
   "map_publicLocationShareConfirm": "Sie werden kurz darauf einen Ort in {channelLabel} teilen. Dieser Kanal ist öffentlich und jeder mit dem PSK kann ihn sehen.",
@@ -652,25 +652,25 @@
     }
   },
   "map_connectToShareMarkers": "Verbinde ein Gerät, um Marker zu teilen",
-  "map_filterNodes": "Filter Knoten",
+  "map_filterNodes": "Knotenfilter",
   "map_nodeTypes": "Knotentypen",
   "map_chatNodes": "Chat-Knoten",
-  "map_repeaters": "Wiederholer",
+  "map_repeaters": "Repeater",
   "map_otherNodes": "Andere Knoten",
   "map_keyPrefix": "Schlüsselpräfix",
   "map_filterByKeyPrefix": "Filter nach Schlüsselpräfix",
-  "map_publicKeyPrefix": "Öffentlicher Schlüsselpräfix",
+  "map_publicKeyPrefix": "Schlüsselpräfix",
   "map_markers": "Marker",
   "map_showSharedMarkers": "Zeige gemeinsam genutzte Marker",
   "map_lastSeenTime": "Letzte Sichtung",
   "map_sharedPin": "Gemeinsames Passwort",
   "map_joinRoom": "Beitreten Sie dem Raum",
-  "map_manageRepeater": "Wiederholung verwalten",
+  "map_manageRepeater": "Repeater verwalten",
   "mapCache_title": "Offline-Karten-Cache",
   "mapCache_selectAreaFirst": "Wählen Sie zuerst einen Bereich zum Zwischenspeichern aus.",
-  "mapCache_noTilesToDownload": "Keine Tiles für diese Region zum Herunterladen verfügbar.",
-  "mapCache_downloadTilesTitle": "Herunterladen von Tiles",
-  "mapCache_downloadTilesPrompt": "Laden {count} Tiles für den Offline-Bereich herunter?",
+  "mapCache_noTilesToDownload": "Keine Kacheln für diese Region zum Herunterladen verfügbar.",
+  "mapCache_downloadTilesTitle": "Herunterladen von Kacheln",
+  "mapCache_downloadTilesPrompt": "Laden {count} Kacheln für den Offline-Bereich herunter?",
   "@mapCache_downloadTilesPrompt": {
     "placeholders": {
       "count": {
@@ -679,7 +679,7 @@
     }
   },
   "mapCache_downloadAction": "Herunterladen",
-  "mapCache_cachedTiles": "Zwischengespeicherte {count} Fliesen",
+  "mapCache_cachedTiles": "Zwischengespeicherte {count} Kacheln",
   "@mapCache_cachedTiles": {
     "placeholders": {
       "count": {
@@ -687,7 +687,7 @@
       }
     }
   },
-  "mapCache_cachedTilesWithFailed": "Zwischengespeicherte {downloaded} Tiles ({failed} fehlgeschlagen)",
+  "mapCache_cachedTilesWithFailed": "Zwischengespeicherte {downloaded} Kacheln ({failed} fehlgeschlagen)",
   "@mapCache_cachedTilesWithFailed": {
     "placeholders": {
       "downloaded": {
@@ -698,7 +698,7 @@
       }
     }
   },
-  "mapCache_clearOfflineCacheTitle": "Leeren Offline-Cache",
+  "mapCache_clearOfflineCacheTitle": "Leere Offline-Cache",
   "mapCache_clearOfflineCachePrompt": "Alle zwischengespeicherten Kartenraster entfernen?",
   "mapCache_offlineCacheCleared": "Offline-Cache gelöscht",
   "mapCache_noAreaSelected": "Kein Bereich ausgewählt",
@@ -724,7 +724,7 @@
       }
     }
   },
-  "mapCache_downloadTilesButton": "Herunterladen von Tiles",
+  "mapCache_downloadTilesButton": "Herunterladen von Kacheln",
   "mapCache_clearCacheButton": "Cache leeren",
   "mapCache_failedDownloads": "Fehlgeschlagene Downloads: {count}",
   "@mapCache_failedDownloads": {
@@ -785,10 +785,10 @@
   "time_month": "Monat",
   "time_months": "Monate",
   "time_minutes": "Minuten",
-  "time_allTime": "Alle Zeit",
+  "time_allTime": "Ganzer Zeitraum",
   "dialog_disconnect": "Trennen",
   "dialog_disconnectConfirm": "Sind Sie sicher, dass Sie sich von diesem Gerät trennen möchten?",
-  "login_repeaterLogin": "Wiederholungseingang anmelden",
+  "login_repeaterLogin": "Beim Repeater anmelden",
   "login_roomLogin": "Raum-Login",
   "login_password": "Passwort",
   "login_enterPassword": "Passwort eingeben",
@@ -799,7 +799,7 @@
   "login_routing": "Routen",
   "login_routingMode": "Routenmodus",
   "login_autoUseSavedPath": "Automatisch (gespeicherten Pfad verwenden)",
-  "login_forceFloodMode": "Zwangsgelände-Modus erzwingen",
+  "login_forceFloodMode": "Flut-Modus erzwingen",
   "login_managePaths": "Pfadverwaltung",
   "login_login": "Anmelden",
   "login_attempt": "Versuche {current}/{max}",
@@ -825,7 +825,7 @@
 
   "common_reload": "Neu laden",
   "common_clear": "Löschen",
-  "path_currentPath": "Aktiger Pfad: {path}",
+  "path_currentPath": "Aktiver Pfad: {path}",
   "@path_currentPath": {
     "placeholders": {
       "path": {
@@ -841,9 +841,9 @@
       }
     }
   },
-  "path_enterCustomPath": "Gib Pfad an",
+  "path_enterCustomPath": "Gebe Pfad ein",
   "path_currentPathLabel": "Aktueller Pfad",
-  "path_hexPrefixInstructions": "Gib für jeden Hopfen 2-stellige Hex-Präfixe ein, getrennt durch Kommas.",
+  "path_hexPrefixInstructions": "Gebe für jeden Hopfen 2-stellige Hex-Präfixe ein, getrennt durch Kommas.",
   "path_hexPrefixExample": "Beispiel: A1,F2,3C (jeder Knoten verwendet den ersten Byte seines öffentlichen Schlüssels)",
   "path_labelHexPrefixes": "Pfad (Hex-Präfixe)",
   "path_helperMaxHops": "Max 64 Sprünge. Jede Präfixe ist 2 Hexadezimalzeichen (1 Byte)",
@@ -860,7 +860,7 @@
   },
   "path_tooLong": "Pfad zu lang. Maximal 64 Hops erlaubt.",
   "path_setPath": "Pfad festlegen",
-  "repeater_management": "Wiederholungselement-Verwaltung",
+  "repeater_management": "Repeater-Verwaltung",
   "repeater_managementTools": "Verwaltungs-Tools",
   "repeater_status": "Status",
   "repeater_statusSubtitle": "Status, Statistiken und Nachbarn anzeigen",
@@ -869,11 +869,11 @@
   "repeater_cli": "CLI",
   "repeater_cliSubtitle": "Sende Befehle an den Repeater",
   "repeater_settings": "Einstellungen",
-  "repeater_settingsSubtitle": "Wiederholungsparameter konfigurieren",
-  "repeater_statusTitle": "Wiederholungszustand",
+  "repeater_settingsSubtitle": "Repeater-parameter konfigurieren",
+  "repeater_statusTitle": "Repeaterstatus",
   "repeater_routingMode": "Routenmodus",
   "repeater_autoUseSavedPath": "Automatisch (gespeicherten Pfad verwenden)",
-  "repeater_forceFloodMode": "Zwangsgelände-Modus erzwingen",
+  "repeater_forceFloodMode": "Flut-Modus erzwingen",
   "repeater_pathManagement": "Pfadverwaltung",
   "repeater_refresh": "Aktualisieren",
   "repeater_statusRequestTimeout": "Statusanfrage zeitweise fehlgeschlagen.",
@@ -965,9 +965,9 @@
       }
     }
   },
-  "repeater_settingsTitle": "Wiederholungseinstellungen",
+  "repeater_settingsTitle": "Repeater Einstellungen",
   "repeater_basicSettings": "Grundlegende Einstellungen",
-  "repeater_repeaterName": "Wiederholungseintrag",
+  "repeater_repeaterName": "Repeater Name",
   "repeater_repeaterNameHelper": "Anzeigename für diesen Repeater",
   "repeater_adminPassword": "Admin-Passwort",
   "repeater_adminPasswordHelper": "Vollzugriffspasswort",
@@ -980,7 +980,7 @@
   "repeater_txPowerHelper": "1-30 dBm",
   "repeater_bandwidth": "Bandbreite",
   "repeater_spreadingFactor": "Verteilungsfaktor",
-  "repeater_codingRate": "Programmierpauschale",
+  "repeater_codingRate": "Kodierungsrate",
   "repeater_locationSettings": "Standort Einstellungen",
   "repeater_latitude": "Breitengrad",
   "repeater_latitudeHelper": "Dezimalgrad (z.B. 37,7749)",
@@ -991,10 +991,10 @@
   "repeater_packetForwardingSubtitle": "Aktivieren Sie den Repeater, um Pakete weiterzuleiten.",
   "repeater_guestAccess": "Gastzugriff",
   "repeater_guestAccessSubtitle": "Gast-Zugriff mit beschränkten Rechten zulassen",
-  "repeater_privacyMode": "Privatschutzzustand",
-  "repeater_privacyModeSubtitle": "Verstecken Sie Name/Ort in Anzeigen",
-  "repeater_advertisementSettings": "Werbe Einstellungen",
-  "repeater_localAdvertInterval": "Lokaler Werbeintervall",
+  "repeater_privacyMode": "Privatsphäreeinstellung",
+  "repeater_privacyModeSubtitle": "Verstecken Sie Name/Ort in Ankündigungen",
+  "repeater_advertisementSettings": "Ankündigungseinstellungen",
+  "repeater_localAdvertInterval": "Intervall der lokalen Ankündigungen",
   "repeater_localAdvertIntervalMinutes": "{minutes} Minuten",
   "@repeater_localAdvertIntervalMinutes": {
     "placeholders": {
@@ -1003,7 +1003,7 @@
       }
     }
   },
-  "repeater_floodAdvertInterval": "Überschwemmungsanzeige-Intervall",
+  "repeater_floodAdvertInterval": "Intervall der gefluteten Ankündigungen",
   "repeater_floodAdvertIntervalHours": "{hours} Stunden",
   "@repeater_floodAdvertIntervalHours": {
     "placeholders": {
@@ -1012,7 +1012,7 @@
       }
     }
   },
-  "repeater_encryptedAdvertInterval": "Verschlüsselte Werbeintervall",
+  "repeater_encryptedAdvertInterval": "Intervall der verschlüsselten Ankündigung",
   "repeater_dangerZone": "Gefahrenzone",
   "repeater_rebootRepeater": "Neustart Repeater",
   "repeater_rebootRepeaterSubtitle": "Wiederholen Sie das Repeater-Gerät.",
@@ -1052,12 +1052,12 @@
   },
   "repeater_refreshBasicSettings": "Grundlegende Einstellungen aktualisieren",
   "repeater_refreshRadioSettings": "Radio-Einstellungen aktualisieren",
-  "repeater_refreshTxPower": "Batterie-Strom aktualisieren",
+  "repeater_refreshTxPower": "Sendeleistung aktualisieren",
   "repeater_refreshLocationSettings": "Aktualisieren Sie die Standort Einstellungen",
   "repeater_refreshPacketForwarding": "Aktualisieren Paketweiterleitung",
   "repeater_refreshGuestAccess": "Aktualisieren Sie den Gastzugriff",
   "repeater_refreshPrivacyMode": "Wiederherstellen des Datenschutzzustands",
-  "repeater_refreshAdvertisementSettings": "Aktualisieren Sie die Werbe Einstellungen",
+  "repeater_refreshAdvertisementSettings": "Aktualisieren Sie die Ankündigungseinstellungen",
   "repeater_refreshed": "{label} wurde aktualisiert",
   "@repeater_refreshed": {
     "placeholders": {
@@ -1074,10 +1074,10 @@
       }
     }
   },
-  "repeater_cliTitle": "Wiederholung CLI",
+  "repeater_cliTitle": "Repeater CLI",
   "repeater_debugNextCommand": "Fehlersuche Nächster Befehl",
   "repeater_commandHelp": "Hilfe",
-  "repeater_clearHistory": "Löschung der Historie",
+  "repeater_clearHistory": "Löschen der Historie",
   "repeater_noCommandsSent": "Noch keine Befehle gesendet.",
   "repeater_typeCommandOrUseQuick": "Geben Sie einen Befehl unten ein oder verwenden Sie Schnellbefehle",
   "repeater_enterCommandHint": "Geben Sie den Befehl ein...",
@@ -1098,37 +1098,37 @@
   "repeater_cliQuickGetTx": "Erhalte TX",
   "repeater_cliQuickNeighbors": "Nachbarn",
   "repeater_cliQuickVersion": "Version",
-  "repeater_cliQuickAdvertise": "Werben",
+  "repeater_cliQuickAdvertise": "Ankündigungen",
   "repeater_cliQuickClock": "Uhr",
-  "repeater_cliHelpAdvert": "Sendet ein Werbepaket",
+  "repeater_cliHelpAdvert": "Sendet eine Ankündigung",
   "repeater_cliHelpReboot": "Startet das Gerät neu. (Beachten Sie, dass es möglicherweise zu einer 'Timeout'-Situation kommt, was normal ist.)",
   "repeater_cliHelpClock": "Zeigt die aktuelle Uhrzeit pro Gerät an.",
   "repeater_cliHelpPassword": "Legt ein neues Administrator-Passwort für das Gerät fest.",
   "repeater_cliHelpVersion": "Zeigt die Geräteversion und das Datum des Firmware-Builds an.",
-  "repeater_cliHelpClearStats": "Setzt verschiedene Statistikkalkulate auf Null zurück.",
+  "repeater_cliHelpClearStats": "Setzt verschiedene Statistikberechnungen auf Null zurück.",
   "repeater_cliHelpSetAf": "Legt den Luftzeitfaktor fest.",
   "repeater_cliHelpSetTx": "Legt die LoRa-Übertragungspower in dBm (bezogen auf 1 Watt) fest. (Neustart erforderlich, um die Änderungen anzuwenden)",
   "repeater_cliHelpSetRepeat": "Aktiviert oder deaktiviert die Repeater-Rolle für diesen Knoten.",
-  "repeater_cliHelpSetAllowReadOnly": "(Raumspeicher) Wenn 'an', dann wird die Anmeldung mit einem leeren Passwort erlaubt sein, aber kann nicht in den Raum geschickt werden. (nur lesen möglich).",
+  "repeater_cliHelpSetAllowReadOnly": "(Raumspeicher) Wenn 'an', dann wird die Anmeldung mit einem leeren Passwort erlaubt sein, aber es kann nicht in den Raum gesendet werden. (nur lesen möglich).",
   "repeater_cliHelpSetFloodMax": "Legt die maximale Anzahl an Hops für Pakete der eingehenden Flut (wenn >= max, wird das Paket nicht weitergeleitet)",
   "repeater_cliHelpSetIntThresh": "Legt den Interferenzeniveau (in dB) fest. Der Standardwert ist 14. Auf 0 setzen, um die Erkennung von Kanalinterferenzen zu deaktivieren.",
   "repeater_cliHelpSetAgcResetInterval": "Legt das Intervall für das Zurücksetzen des Auto Gain Controllers fest. Auf 0 setzen, um die Funktion zu deaktivieren.",
   "repeater_cliHelpSetMultiAcks": "Aktiviert oder deaktiviert die Funktion 'Doppel-ACKs'.",
-  "repeater_cliHelpSetAdvertInterval": "Legt das Timer-Intervall in Minuten fest, um ein lokales (ohne-Weiterleitung) Werbe-Paket zu senden. Auf 0 setzen, um die Funktion zu deaktivieren.",
-  "repeater_cliHelpSetFloodAdvertInterval": "Legt das Timer-Intervall in Stunden für den Versand eines Flut-Werbungspakets fest. Auf 0 setzen, um es zu deaktivieren.",
+  "repeater_cliHelpSetAdvertInterval": "Legt das Timer-Intervall in Minuten fest, um ein lokales (ohne-Weiterleitung) Ankündigungspaket zu senden. Auf 0 setzen, um die Funktion zu deaktivieren.",
+  "repeater_cliHelpSetFloodAdvertInterval": "Legt das Timer-Intervall in Stunden für den Versand eines Flut-Ankündigungspacket fest. Auf 0 setzen, um es zu deaktivieren.",
   "repeater_cliHelpSetGuestPassword": "Legt/aktualisiert das Gastpasswort fest. (für Repeater können Gast-Logins die \"Get Stats\"-Anfrage senden)",
   "repeater_cliHelpSetName": "Legt den Anzeigenamen fest.",
-  "repeater_cliHelpSetLat": "Legt die Breitengrad-Angabe der Werbekarte fest. (dezimale Grad)",
-  "repeater_cliHelpSetLon": "Legt die Längengrade der Werbe-Map fest. (dezimale Grad)",
+  "repeater_cliHelpSetLat": "Legt die Breitengrad der Ankündigung fest. (dezimale Grad)",
+  "repeater_cliHelpSetLon": "Legt die Längengrade der Ankündigung fest. (dezimale Grad)",
   "repeater_cliHelpSetRadio": "Legt komplett neue Radio-Parameter fest und speichert diese als Präferenzen. Benötigt einen \"Reboot\"-Befehl, um sie anzuwenden.",
   "repeater_cliHelpSetRxDelay": "Sets (experimentell) als Basis (muss > 1 sein für den Effekt) zur Anwendung einer leichten Verzögerung bei empfangenen Paketen, basierend auf Signalstärke/Punktzahl. Auf 0 setzen, um die Funktion zu deaktivieren.",
   "repeater_cliHelpSetTxDelay": "Legt einen Faktor fest, der mit der Zeit bei voller Zuluft für ein Flood-Mode-Paket und mit einem zufälligen Slot-System multipliziert wird, um dessen Weiterleitung zu verzögern (um Kollisionen zu vermeiden).",
   "repeater_cliHelpSetDirectTxDelay": "Ähnlich wie txdelay, aber zum Anwenden einer zufälligen Verzögerung bei der Weiterleitung von Direktmodus-Paketen.",
   "repeater_cliHelpSetBridgeEnabled": "Brücke aktivieren/deaktivieren.",
   "repeater_cliHelpSetBridgeDelay": "Setze Verzögerung vor erneuter Übertragung von Paketen.",
-  "repeater_cliHelpSetBridgeSource": "Wählen Sie, ob die Brücke empfangene oder gesendete Pakete erneut übertragen soll.",
+  "repeater_cliHelpSetBridgeSource": "Wählen Sie, ob über die Brücke empfangene oder gesendete Pakete erneut übertragen soll.",
   "repeater_cliHelpSetBridgeBaud": "Setze die serielle Link-Baudrate für RS232-Brücken.",
-  "repeater_cliHelpSetBridgeSecret": "Richte das Espnow-Brücken-Geheimnis ein.",
+  "repeater_cliHelpSetBridgeSecret": "Richte das Brückenpassword ein.",
   "repeater_cliHelpSetAdcMultiplier": "Legt einen benutzerdefinierten Faktor zur Anpassung der gemeldeten Batteriewirkspannung fest (nur auf ausgewählten Boards unterstützt).",
   "repeater_cliHelpTempRadio": "Legt vorübergehende Funkparameter für die angegebene Anzahl von Minuten fest und kehrt anschließend zu den ursprünglichen Funkparametern zurück (wird nicht in den Einstellungen gespeichert).",
   "repeater_cliHelpSetPerm": "Ändert die ACL. Entfernt das passende Eintragen (durch Pubkey-Präfix), wenn \"permissions\" auf 0 steht. Fügt ein neues Eintragen hinzu, wenn die Pubkey-Hex-Länge vollständig ist und nicht bereits in der ACL vorhanden ist. Aktualisiert das Eintragen anhand des übereinstimmenden Pubkey-Präfix. Berechtigungsbits variieren je nach Firmware-Rolle, aber die unteren 2 Bits sind: 0 (Gast), 1 (Nur Lesen), 2 (Lesen/Schreiben), 3 (Admin)",
@@ -1136,9 +1136,9 @@
   "repeater_cliHelpLogStart": "Beginnt die Paketprotokollierung in das Dateisystem.",
   "repeater_cliHelpLogStop": "Stoppt das Paketprotokollieren in das Dateisystem.",
   "repeater_cliHelpLogErase": "Löscht die Paketprotokolle aus dem Dateisystem.",
-  "repeater_cliHelpNeighbors": "Zeigt eine Liste anderer Repeater-Knoten an, die über Zero-Hop-Werbung gehört wurden. Jede Zeile ist id-prefix-hex:timestamp:snr-times-4",
+  "repeater_cliHelpNeighbors": "Zeigt eine Liste anderer Repeater-Knoten an, die über Zero-Hop-Ankündigung gehört wurden. Jede Zeile ist id-prefix-hex:timestamp:snr-times-4",
   "repeater_cliHelpNeighborRemove": "Entfernt das erste übereinstimmende Element (über Pubkey-Präfix (hex)) aus der Liste der Nachbarn.",
-  "repeater_cliHelpRegion": "(Serien nur) Listet alle definierten Regionen und aktuelle Hochwassermissungen auf.",
+  "repeater_cliHelpRegion": "Listet alle definierten Regionen auf.",
   "repeater_cliHelpRegionLoad": "Hinweis: Dies ist ein spezieller Mehrbefehl-Aufruf. Jeder nachfolgende Befehl ist ein Regionsname (eingedruckt mit Leerzeichen zur Angabe der übergeordneten Hierarchie, mit mindestens einem Leerzeichen). Beendet durch das Senden einer Leerzeile/des Befehls.",
   "repeater_cliHelpRegionGet": "Sucht die Region mit dem gegebenen Namenspräfix (oder \"\\\" für den globalen Scope) und antwortet mit \"-> region-name (parent-name) 'F'\".",
   "repeater_cliHelpRegionPut": "Fügt eine Region-Definition mit dem angegebenen Namen hinzu oder aktualisiert diese.",
@@ -1230,12 +1230,12 @@
   "channelPath_title": "Paketpfad",
   "channelPath_viewMap": "Karte anzeigen",
   "channelPath_otherObservedPaths": "Sonstige beobachtete Pfade",
-  "channelPath_repeaterHops": "Wiederholungs-Sprünge",
+  "channelPath_repeaterHops": "Repeater-Sprünge",
   "channelPath_noHopDetails": "Die Detailangaben für dieses Paket sind nicht verfügbar.",
   "channelPath_messageDetails": "Nachrichtsdetails",
   "channelPath_senderLabel": "Sender",
   "channelPath_timeLabel": "Zeit",
-  "channelPath_repeatsLabel": "Wiederholung",
+  "channelPath_repeatsLabel": "Wiederholungen",
   "channelPath_pathLabel": "Pfad {index}",
   "channelPath_observedLabel": "Beobachtet",
   "channelPath_observedPathTitle": "Beobachteter Pfad {index} • {hops}",
@@ -1273,7 +1273,7 @@
     }
   },
   "channelPath_unknownPath": "Unbekannt",
-  "channelPath_floodPath": "Überschwemmung",
+  "channelPath_floodPath": "Geflutet",
   "channelPath_directPath": "Direkt",
   "channelPath_observedZeroOf": "0 von {total} Sprüngen",
   "@channelPath_observedZeroOf": {
@@ -1329,12 +1329,12 @@
   "listFilter_tooltip": "Filteren und sortieren",
   "listFilter_sortBy": "Sortiere nach",
   "listFilter_latestMessages": "Letzte Nachrichten",
-  "listFilter_heardRecently": "Hörte kürzlich",
+  "listFilter_heardRecently": "Kürzlich gehört",
   "listFilter_az": "A-Z",
   "listFilter_filters": "Filtere",
   "listFilter_all": "Alle",
   "listFilter_users": "Benutzer",
-  "listFilter_repeaters": "Wiederholer",
+  "listFilter_repeaters": "Repeater",
   "listFilter_roomServers": "Raumserver",
   "listFilter_unreadOnly": "Nur nicht gelesen",
   "listFilter_newGroup": "Neue Gruppe",

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -141,7 +141,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get scanner_scan => 'Scannen';
 
   @override
-  String get device_quickSwitch => 'Schneller Umschalten';
+  String get device_quickSwitch => 'Schnelles Umschalten';
 
   @override
   String get device_meshcore => 'MeshCore';
@@ -169,7 +169,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_nodeNameNotSet => 'Nicht festgelegt';
 
   @override
-  String get settings_nodeNameHint => 'Gib den Knotenamen ein';
+  String get settings_nodeNameHint => 'Gebe den Knotenamen ein';
 
   @override
   String get settings_nodeNameUpdated => 'Name aktualisiert';
@@ -207,18 +207,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_longitude => 'Längengrad';
 
   @override
-  String get settings_privacyMode => 'Privatschutzzustand';
+  String get settings_privacyMode => 'Privatsphäreeinstellung';
 
   @override
   String get settings_privacyModeSubtitle =>
-      'Verstecken Sie Name/Ort in Anzeigen';
+      'Verstecken Sie Name/Ort in Ankündigungen';
 
   @override
   String get settings_privacyModeToggle =>
-      'Aktivieren Sie den Datenschutzzustand, um Ihren Namen und Ihre Standortdaten in Anzeigen zu verbergen.';
+      'Aktivieren Sie die Privatsphäreeinstellung, um Ihren Namen und Ihre Standortdaten in Ankündigungen zu verbergen.';
 
   @override
-  String get settings_privacyModeEnabled => 'Privatschutzzustand aktiviert';
+  String get settings_privacyModeEnabled => 'Datenschutzmodus aktiviert';
 
   @override
   String get settings_privacyModeDisabled => 'Datenschutzmodus deaktiviert';
@@ -227,20 +227,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_actions => 'Aktionen';
 
   @override
-  String get settings_sendAdvertisement => 'Senden Sie Anzeige';
+  String get settings_sendAdvertisement => 'Sende eine Ankündigung';
 
   @override
-  String get settings_sendAdvertisementSubtitle => 'Sendungsstatus jetzt';
+  String get settings_sendAdvertisementSubtitle => 'Sende Ankündigung';
 
   @override
-  String get settings_advertisementSent => 'Anzeige gesendet';
+  String get settings_advertisementSent => 'Ankündigung gesendet';
 
   @override
-  String get settings_syncTime => 'Synchronisierungszeit';
+  String get settings_syncTime => 'Zeitsynchronisierung';
 
   @override
   String get settings_syncTimeSubtitle =>
-      'Stelle die Gerätewielfalt auf die Uhrzeit des Telefons ein';
+      'Stelle die Gerätezeit auf die Uhrzeit des Telefons ein';
 
   @override
   String get settings_timeSynchronized => 'Zeit synchronisiert';
@@ -309,10 +309,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_infoPublicKey => 'Öffentlicher Schlüssel';
 
   @override
-  String get settings_infoContactsCount => 'Kontakte Anzahl';
+  String get settings_infoContactsCount => 'Anzahl Kontakte';
 
   @override
-  String get settings_infoChannelCount => 'Kanalanzahl';
+  String get settings_infoChannelCount => 'Anzahl Kanäle';
 
   @override
   String get settings_presets => 'Voreinstellungen';
@@ -342,7 +342,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_spreadingFactor => 'Verteilungsfaktor';
 
   @override
-  String get settings_codingRate => 'Programmierpauschale';
+  String get settings_codingRate => 'Kodierungsrate';
 
   @override
   String get settings_txPower => 'TX-Leistung (dBm)';
@@ -354,7 +354,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_txPowerInvalid => 'Ungültige TX-Leistung (0-22 dBm)';
 
   @override
-  String get settings_longRange => 'Langreich';
+  String get settings_longRange => 'Grosse Reichweite';
 
   @override
   String get settings_fastSpeed => 'Schnelle Geschwindigkeit';
@@ -377,7 +377,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appSettings_themeSystem => 'Systemstandard';
 
   @override
-  String get appSettings_themeLight => 'Helligkeit';
+  String get appSettings_themeLight => 'Hell';
 
   @override
   String get appSettings_themeDark => 'Dunkel';
@@ -435,7 +435,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get appSettings_enableNotificationsSubtitle =>
-      'Erhalte Benachrichtigungen für Nachrichten und Anzeigen';
+      'Erhalte Benachrichtigungen für Nachrichten und Ankündigungen';
 
   @override
   String get appSettings_notificationPermissionDenied =>
@@ -450,15 +450,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get appSettings_messageNotifications =>
-      'Nachrichtenbenachrichtigungen';
+      'Direktnachrichten Benachrichtigungen';
 
   @override
   String get appSettings_messageNotificationsSubtitle =>
-      'Zeige Benachrichtigung beim Empfang neuer Nachrichten';
+      'Zeige Benachrichtigung beim Empfang neuer Direktnachrichten';
 
   @override
   String get appSettings_channelMessageNotifications =>
-      'Kanal-Nachrichten-Benachrichtigungen';
+      'Kanalnachrichten Benachrichtigungen';
 
   @override
   String get appSettings_channelMessageNotificationsSubtitle =>
@@ -466,7 +466,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get appSettings_advertisementNotifications =>
-      'Werbeanzeigenbenachrichtigungen';
+      'Ankündigungsbenachrichtigungen';
 
   @override
   String get appSettings_advertisementNotificationsSubtitle =>
@@ -477,11 +477,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get appSettings_clearPathOnMaxRetry =>
-      'Klares Pfad bei Max Wiederholungsversuch';
+      'Lösche Pfade bei Max Wiederholungsversuchen';
 
   @override
   String get appSettings_clearPathOnMaxRetrySubtitle =>
-      'Zurücksetzen des Kontaktpfads nach 5 fehlgeschlagenen Sendeverboten';
+      'Zurücksetzen der Kontaktpfade nach 5 fehlgeschlagenen Sendeabbrüchen';
 
   @override
   String get appSettings_pathsWillBeCleared =>
@@ -566,17 +566,17 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get appSettings_mapTimeFilter => 'Kartent Zeitfilter';
+  String get appSettings_mapTimeFilter => 'Karten Zeitfilter';
 
   @override
   String get appSettings_showNodesDiscoveredWithin =>
       'Zeige Knoten, die innerhalb von:';
 
   @override
-  String get appSettings_allTime => 'Alle Zeit';
+  String get appSettings_allTime => 'Ganzer Zeitverlauf';
 
   @override
-  String get appSettings_lastHour => 'Letzter Stunde';
+  String get appSettings_lastHour => 'Letzte Stunde';
 
   @override
   String get appSettings_last6Hours => 'Letzte 6 Stunden';
@@ -620,48 +620,48 @@ class AppLocalizationsDe extends AppLocalizations {
   String get contacts_title => 'Kontakte';
 
   @override
-  String get contacts_noContacts => 'No Contacts noch';
+  String get contacts_noContacts => 'Noch keine Kontakte vorhanden.';
 
   @override
   String get contacts_contactsWillAppear =>
-      'Kontakte werden angezeigt, wenn Geräte Werbung machen.';
+      'Kontakte werden angezeigt, wenn Geräte eine Ankündigung machen.';
 
   @override
   String get contacts_searchContacts => 'Suche Kontakte...';
 
   @override
-  String get contacts_noUnreadContacts => 'Keine ungeklärten Kontakte';
+  String get contacts_noUnreadContacts => 'Keine ungesehene Kontakte';
 
   @override
   String get contacts_noContactsFound =>
       'Keine Kontakte oder Gruppen gefunden.';
 
   @override
-  String get contacts_deleteContact => 'Löschen Sie Kontakt';
+  String get contacts_deleteContact => 'Lösche den Kontakt';
 
   @override
   String contacts_removeConfirm(String contactName) {
-    return 'Entfernen $contactName aus den Kontakten?';
+    return '$contactName aus den Kontakten entfernen?';
   }
 
   @override
-  String get contacts_manageRepeater => 'Wiederholung verwalten';
+  String get contacts_manageRepeater => 'Wiederholungen verwalten';
 
   @override
   String get contacts_roomLogin => 'Raum-Login';
 
   @override
-  String get contacts_openChat => 'Öffnen Sie Chat';
+  String get contacts_openChat => 'Öffne Chat';
 
   @override
-  String get contacts_editGroup => 'Gruppen bearbeiten';
+  String get contacts_editGroup => 'Gruppe bearbeiten';
 
   @override
   String get contacts_deleteGroup => 'Löschen Gruppe';
 
   @override
   String contacts_deleteGroupConfirm(String groupName) {
-    return 'Löschen Sie \"$groupName\"?';
+    return 'Löschen von \"$groupName\"?';
   }
 
   @override
@@ -689,11 +689,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get contacts_noMembers => 'Keine Mitglieder';
 
   @override
-  String get contacts_lastSeenNow => 'Letztes Ansehen jetzt';
+  String get contacts_lastSeenNow => 'gerade gesehen';
 
   @override
   String contacts_lastSeenMinsAgo(int minutes) {
-    return 'Letzte Sichtung $minutes Minuten her.';
+    return 'Letzte Sichtung vor $minutes Minuten.';
   }
 
   @override
@@ -701,7 +701,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String contacts_lastSeenHoursAgo(int hours) {
-    return 'Letzte Aktivität vor $hours Stunden.';
+    return 'Letzte Sichtung vor $hours Stunden.';
   }
 
   @override
@@ -751,11 +751,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channels_editChannel => 'Kanal bearbeiten';
 
   @override
-  String get channels_deleteChannel => 'Löschen Sie Kanal';
+  String get channels_deleteChannel => 'Lösche den Kanal';
 
   @override
   String channels_deleteChannelConfirm(String name) {
-    return 'Löschen \"$name\"? Dies kann nicht rückgängig gemacht werden.';
+    return 'Löschen von \"$name\"? Dies kann nicht rückgängig gemacht werden.';
   }
 
   @override
@@ -799,7 +799,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String channels_editChannelTitle(int index) {
-    return 'Bearbeiteten Kanal $index';
+    return 'Bearbeiteter Kanal $index';
   }
 
   @override
@@ -817,7 +817,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channels_sortBy => 'Sortiere nach';
 
   @override
-  String get channels_sortManual => 'Manuelle';
+  String get channels_sortManual => 'Manuell';
 
   @override
   String get channels_sortAZ => 'A bis Z';
@@ -826,7 +826,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channels_sortLatestMessages => 'Letzte Nachrichten';
 
   @override
-  String get channels_sortUnread => 'Unlescht';
+  String get channels_sortUnread => 'Ungelesen';
 
   @override
   String get channels_createPrivateChannel => 'Erstelle einen privaten Kanal';
@@ -886,7 +886,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String chat_replyTo(String name) {
-    return 'Antworten Sie $name';
+    return 'Antwort an $name';
   }
 
   @override
@@ -916,7 +916,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String chat_retryCount(int current, int max) {
-    return 'Versuchen $current/$max';
+    return 'Versuche $current/$max';
   }
 
   @override
@@ -950,14 +950,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get gifPicker_searchHint => 'Suche nach GIFs...';
 
   @override
-  String get gifPicker_poweredBy => 'Angetrieben von GIPHY';
+  String get gifPicker_poweredBy => 'Bereitgestellt von GIPHY';
 
   @override
   String get gifPicker_noGifsFound => 'Keine GIFs gefunden';
 
   @override
-  String get gifPicker_failedLoad =>
-      'GIF-Dateien konnten nicht geladen werden.';
+  String get gifPicker_failedLoad => 'GIF-Datei konnten nicht geladen werden.';
 
   @override
   String get gifPicker_failedSearch => 'Suche nach GIFs fehlgeschlagen';
@@ -972,10 +971,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get debugLog_bleTitle => 'BLE-Debug-Protokoll';
 
   @override
-  String get debugLog_copyLog => 'Kopieren Sie Protokoll';
+  String get debugLog_copyLog => 'Kopieren des Protokolls';
 
   @override
-  String get debugLog_clearLog => 'Log löschen';
+  String get debugLog_clearLog => 'Protokoll löschen';
 
   @override
   String get debugLog_copied => 'Debug-Protokoll kopiert';
@@ -997,7 +996,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get debugLog_rawLogRx => 'Roh-Log-RX';
 
   @override
-  String get debugLog_noBleActivity => 'No BLE-Aktivität bisher';
+  String get debugLog_noBleActivity => 'Bisher keine BLE-Aktivität';
 
   @override
   String debugFrame_length(int count) {
@@ -1057,7 +1056,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Automatisch (gespeicherten Pfad verwenden)';
 
   @override
-  String get chat_forceFloodMode => 'Zwangsgelände-Modus erzwingen';
+  String get chat_forceFloodMode => 'Flut-Modus erzwingen';
 
   @override
   String get chat_recentAckPaths =>
@@ -1068,31 +1067,31 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Pfadhistorie ist voll. Entferne Einträge, um neue hinzuzufügen.';
 
   @override
-  String get chat_hopSingular => 'Springe';
+  String get chat_hopSingular => 'Sprung';
 
   @override
-  String get chat_hopPlural => 'Hops';
+  String get chat_hopPlural => 'Sprünge';
 
   @override
   String chat_hopsCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Hops',
-      one: 'Hop',
+      other: 'Sprünge',
+      one: 'Sprung',
     );
     return '$count $_temp0';
   }
 
   @override
-  String get chat_successes => 'Erfolgreiche';
+  String get chat_successes => 'Erfolgreich';
 
   @override
   String get chat_removePath => 'Pfad entfernen';
 
   @override
   String get chat_noPathHistoryYet =>
-      'Noe eine Pfadhistorie vorhanden.\nSende eine Nachricht, um Pfade zu entdecken.';
+      'Keine eine Pfadhistorie vorhanden.\nSende eine Nachricht, um Pfade zu entdecken.';
 
   @override
   String get chat_pathActions => 'Pfadaktionen:';
@@ -1101,26 +1100,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chat_setCustomPath => 'Lege benutzerdefinierten Pfad fest';
 
   @override
-  String get chat_setCustomPathSubtitle => 'Manuelle Routenpfad festlegen';
+  String get chat_setCustomPathSubtitle => 'Manuellen Routenpfad festlegen';
 
   @override
-  String get chat_clearPath => 'Klares Pfad';
+  String get chat_clearPath => 'Pfad zurücksetzen';
 
   @override
   String get chat_clearPathSubtitle =>
-      'Zwinge bei nächster Sendung eine erneute Entdeckung durch.';
+      'Setze Pfad zurück, erkenne neuen Pfad bei nächster Sendung.';
 
   @override
   String get chat_pathCleared =>
-      'Pfad freigelegt. Nächste Nachricht wird Route neu entdecken.';
+      'Pfad zurückgesetzt. Nächste Nachricht wird Route neu entdecken.';
 
   @override
   String get chat_floodModeSubtitle =>
       'Verwende den Routingschalter in der App-Leiste';
 
   @override
-  String get chat_floodModeEnabled =>
-      'Flutmodus aktiviert. Über den Routing-Icon in der App-Leiste wieder aktivieren.';
+  String get chat_floodModeEnabled => 'Flutmodus aktiviert.';
 
   @override
   String get chat_fullPath => 'Vollständiger Pfad';
@@ -1142,7 +1140,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chat_pathSavedLocally =>
-      'Gespeichert lokal. Mit Verbinden zum Synchronisieren.';
+      'Lokal Gespeichert. Bitte Verbinden zum Synchronisieren.';
 
   @override
   String get chat_pathDeviceConfirmed => 'Gerät bestätigt.';
@@ -1151,7 +1149,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chat_pathDeviceNotConfirmed => 'Gerät noch nicht bestätigt.';
 
   @override
-  String get chat_type => 'Gib ein';
+  String get chat_type => 'Gebe ein';
 
   @override
   String get chat_path => 'Pfad';
@@ -1161,13 +1159,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chat_compressOutgoingMessages =>
-      'Komprimieren ausgehende Nachrichten';
+      'Komprimieren ausgehender Nachrichten';
 
   @override
-  String get chat_floodForced => 'Überschwemmung (erzwungen)';
+  String get chat_floodForced => 'Geflutet (erzwungen)';
 
   @override
-  String get chat_directForced => 'Direkt (gezwungen)';
+  String get chat_directForced => 'Direkt (erzwungen)';
 
   @override
   String chat_hopsForced(int count) {
@@ -1175,28 +1173,28 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get chat_floodAuto => 'Überschwemmung (automatisch)';
+  String get chat_floodAuto => 'Geflutet (automatisch)';
 
   @override
   String get chat_direct => 'Direkt';
 
   @override
-  String get chat_poiShared => 'Gemeinsamer POI';
+  String get chat_poiShared => 'Geteilter POI';
 
   @override
   String chat_unread(int count) {
-    return 'Unlescht: $count';
+    return 'Ungelesen: $count';
   }
 
   @override
-  String get map_title => 'Knotenkarte';
+  String get map_title => 'Karte';
 
   @override
   String get map_noNodesWithLocation => 'Keine Knoten mit Standortdaten';
 
   @override
   String get map_nodesNeedGps =>
-      'Knoten müssen ihre GPS-Koordinaten\nteilen,\num auf der Karte\nerscheinen.';
+      'Knoten müssen ihre GPS-Koordinaten teilen,\num auf der Karte zu erscheinen.';
 
   @override
   String map_nodesCount(int count) {
@@ -1209,10 +1207,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get map_chat => 'Chat';
+  String get map_chat => 'Benutzer';
 
   @override
-  String get map_repeater => 'Wiederholung';
+  String get map_repeater => 'Repeater';
 
   @override
   String get map_room => 'Raum';
@@ -1221,13 +1219,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_sensor => 'Sensor';
 
   @override
-  String get map_pinDm => 'Sperren (DM)';
+  String get map_pinDm => 'Pin (Kontakt)';
 
   @override
-  String get map_pinPrivate => 'Privat-Pin';
+  String get map_pinPrivate => 'Pin (Channel)';
 
   @override
-  String get map_pinPublic => 'Öffentliche Taste (PIN)';
+  String get map_pinPublic => 'Pin (Public)';
 
   @override
   String get map_lastSeen => 'Letzte Sichtung';
@@ -1243,13 +1241,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_source => 'Quelle';
 
   @override
-  String get map_flags => 'Flaggen';
+  String get map_flags => 'Flags';
 
   @override
-  String get map_shareMarkerHere => 'Teilen Sie hier das Marker.';
+  String get map_shareMarkerHere => 'Teilen Sie den Marker hier.';
 
   @override
-  String get map_pinLabel => 'Kennzeichnungslabel';
+  String get map_pinLabel => 'Pin Name';
 
   @override
   String get map_label => 'Label';
@@ -1261,7 +1259,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_sendToContact => 'Senden an Kontakt';
 
   @override
-  String get map_sendToChannel => 'Senden Sie Kanal';
+  String get map_sendToChannel => 'Senden an Kanal';
 
   @override
   String get map_noChannelsAvailable => 'Keine Kanäle verfügbar';
@@ -1279,7 +1277,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verbinde ein Gerät, um Marker zu teilen';
 
   @override
-  String get map_filterNodes => 'Filter Knoten';
+  String get map_filterNodes => 'Knotenfilter';
 
   @override
   String get map_nodeTypes => 'Knotentypen';
@@ -1288,7 +1286,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_chatNodes => 'Chat-Knoten';
 
   @override
-  String get map_repeaters => 'Wiederholer';
+  String get map_repeaters => 'Repeater';
 
   @override
   String get map_otherNodes => 'Andere Knoten';
@@ -1300,7 +1298,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_filterByKeyPrefix => 'Filter nach Schlüsselpräfix';
 
   @override
-  String get map_publicKeyPrefix => 'Öffentlicher Schlüsselpräfix';
+  String get map_publicKeyPrefix => 'Schlüsselpräfix';
 
   @override
   String get map_markers => 'Marker';
@@ -1318,7 +1316,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_joinRoom => 'Beitreten Sie dem Raum';
 
   @override
-  String get map_manageRepeater => 'Wiederholung verwalten';
+  String get map_manageRepeater => 'Repeater verwalten';
 
   @override
   String get mapCache_title => 'Offline-Karten-Cache';
@@ -1329,14 +1327,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get mapCache_noTilesToDownload =>
-      'Keine Tiles für diese Region zum Herunterladen verfügbar.';
+      'Keine Kacheln für diese Region zum Herunterladen verfügbar.';
 
   @override
-  String get mapCache_downloadTilesTitle => 'Herunterladen von Tiles';
+  String get mapCache_downloadTilesTitle => 'Herunterladen von Kacheln';
 
   @override
   String mapCache_downloadTilesPrompt(int count) {
-    return 'Laden $count Tiles für den Offline-Bereich herunter?';
+    return 'Laden $count Kacheln für den Offline-Bereich herunter?';
   }
 
   @override
@@ -1344,16 +1342,16 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String mapCache_cachedTiles(int count) {
-    return 'Zwischengespeicherte $count Fliesen';
+    return 'Zwischengespeicherte $count Kacheln';
   }
 
   @override
   String mapCache_cachedTilesWithFailed(int downloaded, int failed) {
-    return 'Zwischengespeicherte $downloaded Tiles ($failed fehlgeschlagen)';
+    return 'Zwischengespeicherte $downloaded Kacheln ($failed fehlgeschlagen)';
   }
 
   @override
-  String get mapCache_clearOfflineCacheTitle => 'Leeren Offline-Cache';
+  String get mapCache_clearOfflineCacheTitle => 'Leere Offline-Cache';
 
   @override
   String get mapCache_clearOfflineCachePrompt =>
@@ -1385,7 +1383,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get mapCache_downloadTilesButton => 'Herunterladen von Tiles';
+  String get mapCache_downloadTilesButton => 'Herunterladen von Kacheln';
 
   @override
   String get mapCache_clearCacheButton => 'Cache leeren';
@@ -1451,7 +1449,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get time_minutes => 'Minuten';
 
   @override
-  String get time_allTime => 'Alle Zeit';
+  String get time_allTime => 'Ganzer Zeitraum';
 
   @override
   String get dialog_disconnect => 'Trennen';
@@ -1461,7 +1459,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Sind Sie sicher, dass Sie sich von diesem Gerät trennen möchten?';
 
   @override
-  String get login_repeaterLogin => 'Wiederholungseingang anmelden';
+  String get login_repeaterLogin => 'Beim Repeater anmelden';
 
   @override
   String get login_roomLogin => 'Raum-Login';
@@ -1498,7 +1496,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Automatisch (gespeicherten Pfad verwenden)';
 
   @override
-  String get login_forceFloodMode => 'Zwangsgelände-Modus erzwingen';
+  String get login_forceFloodMode => 'Flut-Modus erzwingen';
 
   @override
   String get login_managePaths => 'Pfadverwaltung';
@@ -1528,7 +1526,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String path_currentPath(String path) {
-    return 'Aktiger Pfad: $path';
+    return 'Aktiver Pfad: $path';
   }
 
   @override
@@ -1543,14 +1541,14 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get path_enterCustomPath => 'Gib Pfad an';
+  String get path_enterCustomPath => 'Gebe Pfad ein';
 
   @override
   String get path_currentPathLabel => 'Aktueller Pfad';
 
   @override
   String get path_hexPrefixInstructions =>
-      'Gib für jeden Hopfen 2-stellige Hex-Präfixe ein, getrennt durch Kommas.';
+      'Gebe für jeden Hopfen 2-stellige Hex-Präfixe ein, getrennt durch Kommas.';
 
   @override
   String get path_hexPrefixExample =>
@@ -1586,7 +1584,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get path_setPath => 'Pfad festlegen';
 
   @override
-  String get repeater_management => 'Wiederholungselement-Verwaltung';
+  String get repeater_management => 'Repeater-Verwaltung';
 
   @override
   String get repeater_managementTools => 'Verwaltungs-Tools';
@@ -1615,11 +1613,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get repeater_settings => 'Einstellungen';
 
   @override
-  String get repeater_settingsSubtitle =>
-      'Wiederholungsparameter konfigurieren';
+  String get repeater_settingsSubtitle => 'Repeater-parameter konfigurieren';
 
   @override
-  String get repeater_statusTitle => 'Wiederholungszustand';
+  String get repeater_statusTitle => 'Repeaterstatus';
 
   @override
   String get repeater_routingMode => 'Routenmodus';
@@ -1629,7 +1626,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Automatisch (gespeicherten Pfad verwenden)';
 
   @override
-  String get repeater_forceFloodMode => 'Zwangsgelände-Modus erzwingen';
+  String get repeater_forceFloodMode => 'Flut-Modus erzwingen';
 
   @override
   String get repeater_pathManagement => 'Pfadverwaltung';
@@ -1725,13 +1722,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get repeater_settingsTitle => 'Wiederholungseinstellungen';
+  String get repeater_settingsTitle => 'Repeater Einstellungen';
 
   @override
   String get repeater_basicSettings => 'Grundlegende Einstellungen';
 
   @override
-  String get repeater_repeaterName => 'Wiederholungseintrag';
+  String get repeater_repeaterName => 'Repeater Name';
 
   @override
   String get repeater_repeaterNameHelper => 'Anzeigename für diesen Repeater';
@@ -1771,7 +1768,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get repeater_spreadingFactor => 'Verteilungsfaktor';
 
   @override
-  String get repeater_codingRate => 'Programmierpauschale';
+  String get repeater_codingRate => 'Kodierungsrate';
 
   @override
   String get repeater_locationSettings => 'Standort Einstellungen';
@@ -1806,17 +1803,18 @@ class AppLocalizationsDe extends AppLocalizations {
       'Gast-Zugriff mit beschränkten Rechten zulassen';
 
   @override
-  String get repeater_privacyMode => 'Privatschutzzustand';
+  String get repeater_privacyMode => 'Privatsphäreeinstellung';
 
   @override
   String get repeater_privacyModeSubtitle =>
-      'Verstecken Sie Name/Ort in Anzeigen';
+      'Verstecken Sie Name/Ort in Ankündigungen';
 
   @override
-  String get repeater_advertisementSettings => 'Werbe Einstellungen';
+  String get repeater_advertisementSettings => 'Ankündigungseinstellungen';
 
   @override
-  String get repeater_localAdvertInterval => 'Lokaler Werbeintervall';
+  String get repeater_localAdvertInterval =>
+      'Intervall der lokalen Ankündigungen';
 
   @override
   String repeater_localAdvertIntervalMinutes(int minutes) {
@@ -1824,7 +1822,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get repeater_floodAdvertInterval => 'Überschwemmungsanzeige-Intervall';
+  String get repeater_floodAdvertInterval =>
+      'Intervall der gefluteten Ankündigungen';
 
   @override
   String repeater_floodAdvertIntervalHours(int hours) {
@@ -1833,7 +1832,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_encryptedAdvertInterval =>
-      'Verschlüsselte Werbeintervall';
+      'Intervall der verschlüsselten Ankündigung';
 
   @override
   String get repeater_dangerZone => 'Gefahrenzone';
@@ -1906,7 +1905,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Radio-Einstellungen aktualisieren';
 
   @override
-  String get repeater_refreshTxPower => 'Batterie-Strom aktualisieren';
+  String get repeater_refreshTxPower => 'Sendeleistung aktualisieren';
 
   @override
   String get repeater_refreshLocationSettings =>
@@ -1925,7 +1924,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_refreshAdvertisementSettings =>
-      'Aktualisieren Sie die Werbe Einstellungen';
+      'Aktualisieren Sie die Ankündigungseinstellungen';
 
   @override
   String repeater_refreshed(String label) {
@@ -1938,7 +1937,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get repeater_cliTitle => 'Wiederholung CLI';
+  String get repeater_cliTitle => 'Repeater CLI';
 
   @override
   String get repeater_debugNextCommand => 'Fehlersuche Nächster Befehl';
@@ -1947,7 +1946,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get repeater_commandHelp => 'Hilfe';
 
   @override
-  String get repeater_clearHistory => 'Löschung der Historie';
+  String get repeater_clearHistory => 'Löschen der Historie';
 
   @override
   String get repeater_noCommandsSent => 'Noch keine Befehle gesendet.';
@@ -1992,13 +1991,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get repeater_cliQuickVersion => 'Version';
 
   @override
-  String get repeater_cliQuickAdvertise => 'Werben';
+  String get repeater_cliQuickAdvertise => 'Ankündigungen';
 
   @override
   String get repeater_cliQuickClock => 'Uhr';
 
   @override
-  String get repeater_cliHelpAdvert => 'Sendet ein Werbepaket';
+  String get repeater_cliHelpAdvert => 'Sendet eine Ankündigung';
 
   @override
   String get repeater_cliHelpReboot =>
@@ -2018,7 +2017,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpClearStats =>
-      'Setzt verschiedene Statistikkalkulate auf Null zurück.';
+      'Setzt verschiedene Statistikberechnungen auf Null zurück.';
 
   @override
   String get repeater_cliHelpSetAf => 'Legt den Luftzeitfaktor fest.';
@@ -2033,7 +2032,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpSetAllowReadOnly =>
-      '(Raumspeicher) Wenn \'an\', dann wird die Anmeldung mit einem leeren Passwort erlaubt sein, aber kann nicht in den Raum geschickt werden. (nur lesen möglich).';
+      '(Raumspeicher) Wenn \'an\', dann wird die Anmeldung mit einem leeren Passwort erlaubt sein, aber es kann nicht in den Raum gesendet werden. (nur lesen möglich).';
 
   @override
   String get repeater_cliHelpSetFloodMax =>
@@ -2053,11 +2052,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpSetAdvertInterval =>
-      'Legt das Timer-Intervall in Minuten fest, um ein lokales (ohne-Weiterleitung) Werbe-Paket zu senden. Auf 0 setzen, um die Funktion zu deaktivieren.';
+      'Legt das Timer-Intervall in Minuten fest, um ein lokales (ohne-Weiterleitung) Ankündigungspaket zu senden. Auf 0 setzen, um die Funktion zu deaktivieren.';
 
   @override
   String get repeater_cliHelpSetFloodAdvertInterval =>
-      'Legt das Timer-Intervall in Stunden für den Versand eines Flut-Werbungspakets fest. Auf 0 setzen, um es zu deaktivieren.';
+      'Legt das Timer-Intervall in Stunden für den Versand eines Flut-Ankündigungspacket fest. Auf 0 setzen, um es zu deaktivieren.';
 
   @override
   String get repeater_cliHelpSetGuestPassword =>
@@ -2068,11 +2067,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpSetLat =>
-      'Legt die Breitengrad-Angabe der Werbekarte fest. (dezimale Grad)';
+      'Legt die Breitengrad der Ankündigung fest. (dezimale Grad)';
 
   @override
   String get repeater_cliHelpSetLon =>
-      'Legt die Längengrade der Werbe-Map fest. (dezimale Grad)';
+      'Legt die Längengrade der Ankündigung fest. (dezimale Grad)';
 
   @override
   String get repeater_cliHelpSetRadio =>
@@ -2100,7 +2099,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpSetBridgeSource =>
-      'Wählen Sie, ob die Brücke empfangene oder gesendete Pakete erneut übertragen soll.';
+      'Wählen Sie, ob über die Brücke empfangene oder gesendete Pakete erneut übertragen soll.';
 
   @override
   String get repeater_cliHelpSetBridgeBaud =>
@@ -2108,7 +2107,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpSetBridgeSecret =>
-      'Richte das Espnow-Brücken-Geheimnis ein.';
+      'Richte das Brückenpassword ein.';
 
   @override
   String get repeater_cliHelpSetAdcMultiplier =>
@@ -2140,15 +2139,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get repeater_cliHelpNeighbors =>
-      'Zeigt eine Liste anderer Repeater-Knoten an, die über Zero-Hop-Werbung gehört wurden. Jede Zeile ist id-prefix-hex:timestamp:snr-times-4';
+      'Zeigt eine Liste anderer Repeater-Knoten an, die über Zero-Hop-Ankündigung gehört wurden. Jede Zeile ist id-prefix-hex:timestamp:snr-times-4';
 
   @override
   String get repeater_cliHelpNeighborRemove =>
       'Entfernt das erste übereinstimmende Element (über Pubkey-Präfix (hex)) aus der Liste der Nachbarn.';
 
   @override
-  String get repeater_cliHelpRegion =>
-      '(Serien nur) Listet alle definierten Regionen und aktuelle Hochwassermissungen auf.';
+  String get repeater_cliHelpRegion => 'Listet alle definierten Regionen auf.';
 
   @override
   String get repeater_cliHelpRegionLoad =>
@@ -2310,7 +2308,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channelPath_otherObservedPaths => 'Sonstige beobachtete Pfade';
 
   @override
-  String get channelPath_repeaterHops => 'Wiederholungs-Sprünge';
+  String get channelPath_repeaterHops => 'Repeater-Sprünge';
 
   @override
   String get channelPath_noHopDetails =>
@@ -2326,7 +2324,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channelPath_timeLabel => 'Zeit';
 
   @override
-  String get channelPath_repeatsLabel => 'Wiederholung';
+  String get channelPath_repeatsLabel => 'Wiederholungen';
 
   @override
   String channelPath_pathLabel(int index) {
@@ -2358,7 +2356,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channelPath_unknownPath => 'Unbekannt';
 
   @override
-  String get channelPath_floodPath => 'Überschwemmung';
+  String get channelPath_floodPath => 'Geflutet';
 
   @override
   String get channelPath_directPath => 'Direkt';
@@ -2413,7 +2411,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get listFilter_latestMessages => 'Letzte Nachrichten';
 
   @override
-  String get listFilter_heardRecently => 'Hörte kürzlich';
+  String get listFilter_heardRecently => 'Kürzlich gehört';
 
   @override
   String get listFilter_az => 'A-Z';
@@ -2428,7 +2426,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get listFilter_users => 'Benutzer';
 
   @override
-  String get listFilter_repeaters => 'Wiederholer';
+  String get listFilter_repeaters => 'Repeater';
 
   @override
   String get listFilter_roomServers => 'Raumserver';


### PR DESCRIPTION
Reworked german translations on current version for clean Pull-reequest.

I do not have access to all windows, therefore some context may be wrong.
Decided to translate:

    "Anounce" to "Ankündigung"
    "Flood" zu "Fluten"
    Repeater has been reverted to the DEnglisch Repeater, because the only german alternative "Verstärker" (amplifier) does not transport the right meaning.

Sincerely Eric
