### PR TITLE
remove msg notify prefix when preview avail

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -206,7 +206,7 @@ class NotificationService {
     final preview = _truncateMessage(message, 30);
     final body = preview.isEmpty
         ? 'Received new message'
-        : 'Received new message: $preview';
+        : preview;
 
     await _notifications.show(
       channelIndex?.hashCode ?? DateTime.now().millisecondsSinceEpoch,


### PR DESCRIPTION
this removes the 'Received new message: ' prefix from notications when there is a message preview available

fixes #49