### PR TITLE
Prevent disconnection handling when already disconnected

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -990,6 +990,7 @@ class MeshCoreConnector extends ChangeNotifier {
   }
 
   Future<void> _requestDeviceInfo() async {
+    if (!isConnected || _awaitingSelfInfo) return;
     _awaitingSelfInfo = true;
     await sendFrame(buildDeviceQueryFrame());
     await sendFrame(buildAppStartFrame());


### PR DESCRIPTION
This cures a race condition that was messing up the disconnection handler.
Before the bluetooth device was fully connected _handleDisconnection() was being call from the lisener.