### PR TITLE
remove direct msg notification prefix

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -118,7 +118,7 @@ class NotificationService {
 
     await _notifications.show(
       contactId?.hashCode ?? 0,
-      'New message from $contactName',
+      contactName,
       message,
       notificationDetails,
       payload: 'message:$contactId',


### PR DESCRIPTION
The prefix "New message from " takes up a lot of space and was not localized anyway.

closes #128