### PR TITLE
remove rotation in path map

### DIFF
--- a/lib/screens/channel_message_path_screen.dart
+++ b/lib/screens/channel_message_path_screen.dart
@@ -349,6 +349,9 @@ class _ChannelMessagePathMapScreenState
                           ),
                     minZoom: 2.0,
                     maxZoom: 18.0,
+                    interactionOptions: InteractionOptions(
+                      flags: ~InteractiveFlag.rotate,
+                    ),
                   ),
                   children: [
                     TileLayer(


### PR DESCRIPTION
when zooming on the path map view window the rotation was too easy to trigger and provided little value to understanding the path

closes #85 