### PR TITLE
Feature: Sync messages sent on the node

### DIFF
--- a/lib/models/channel_message.dart
+++ b/lib/models/channel_message.dart
@@ -171,12 +171,14 @@ class ChannelMessage {
 
     final decodedText = Smaz.tryDecodePrefixed(actualText) ?? actualText;
 
+    final isOutgoingMsg = pathLen == 0;
+
     return ChannelMessage(
       senderKey: null,
       senderName: senderName,
       text: decodedText,
       timestamp: DateTime.fromMillisecondsSinceEpoch(timestampRaw * 1000),
-      isOutgoing: false,
+      isOutgoing: isOutgoingMsg,
       status: ChannelMessageStatus.sent,
       pathLength: pathLen,
       pathBytes: pathBytes,


### PR DESCRIPTION
This makes it so that messages can be sent on the device and synced back using the same sync queue. This is not possible with the vanilla firmware but opens up the possibility for custom firmware that supports this such as my implementation here: https://github.com/ChaoticLeah/MeshCore/tree/feature/send-messages-on-device
