### PR TITLE
Fix battery chemistry dropdown layout overflow

### DIFF
--- a/lib/screens/app_settings_screen.dart
+++ b/lib/screens/app_settings_screen.dart
@@ -384,6 +384,7 @@ class AppSettingsScreen extends StatelessWidget {
     );
   }
 
+  // Fixed rendering issues
   Widget _buildBatteryCard(
     BuildContext context,
     AppSettingsService settingsService,
@@ -399,6 +400,7 @@ class AppSettingsScreen extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          const SizedBox(height: 4),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
             child: Text(
@@ -406,6 +408,8 @@ class AppSettingsScreen extends StatelessWidget {
               style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
           ),
+
+          // Main tile (icon + text only)
           ListTile(
             leading: const Icon(Icons.battery_full),
             title: Text(context.l10n.appSettings_batteryChemistry),
@@ -416,8 +420,19 @@ class AppSettingsScreen extends StatelessWidget {
                     )
                   : context.l10n.appSettings_batteryChemistryConnectFirst,
             ),
-            trailing: DropdownButton<String>(
-              value: selection,
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          ),
+
+          // Dropdown (separate full-width row)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: DropdownButtonFormField<String>(
+              initialValue: selection,
+              isExpanded: true,
+              decoration: const InputDecoration(
+                border: UnderlineInputBorder(),
+                isDense: true,
+              ),
               onChanged: isConnected
                   ? (value) {
                       if (value != null) {


### PR DESCRIPTION
# Fix Battery Settings Layout Overflow (Dropdown Causing Vertical Text Wrap)

##  Problem

The **Battery Chemistry** row in App Settings was rendering incorrectly on smaller screens and certain device widths.

Observed issues:
- Subtitle text (“Set per device …”) collapsed horizontally.
- Text rendered vertically, wrapping one character per line.
- Layout appeared broken and unreadable.

This occurred because the `DropdownButton` was placed inside the `trailing:` slot of a `ListTile`, alongside:
- leading icon
- title
- long subtitle
- dropdown control

The `ListTile` could not satisfy layout constraints, so Flutter compressed the subtitle to near-zero width, forcing character-by-character wrapping.

---

##  Root Cause

`ListTile.trailing` is width-constrained and intended for compact widgets (icons, switches, small controls).

Placing a wide widget like `DropdownButton` in `trailing:` caused horizontal constraint pressure. Flutter resolved this by shrinking the subtitle first, leading to vertical text collapse.

---

##  Solution

Restructured the layout as follows:

1. Keep `ListTile` responsible only for:
   - leading
   - title
   - subtitle

2. Move the dropdown out of `ListTile.trailing`.

3. Render the dropdown as a full-width control beneath the tile.

4. Use `DropdownButtonFormField` with:
   - `isExpanded: true`
   - Proper `InputDecoration`
   - Consistent horizontal padding

This ensures:
- The dropdown gets full horizontal width.
- The subtitle keeps correct wrapping behavior.
- No layout compression occurs.
- Material spacing remains consistent.

---

##  Implementation Changes

Before:
- `DropdownButton` inside `ListTile.trailing`

After:
- `ListTile` handles text only
- `DropdownButtonFormField` rendered beneath it
- Added `isExpanded: true`
- Explicit padding for proper alignment

---

## Result

- Subtitle renders correctly (no vertical collapse)
- UI matches intended Material layout
- Improved responsiveness on smaller devices
- Localization-safe for longer strings
- Cleaner separation of layout responsibilities

---

##  Testing

Tested:
- Small screen widths
- Long device names
- Different localization strings
- Connected and disconnected states

No layout regressions observed.

---

##  Rationale

This aligns with Flutter layout best practices:
- `ListTile.trailing` should only contain compact widgets.
- Larger interactive controls should be placed outside of `ListTile`.

This change prevents future constraint-related UI issues.
