### PR TITLE
Align Android app module to Java 17 and bump wakelock_plus

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,13 +19,13 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
         isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   cached_network_image: ^3.4.1
   flutter_cache_manager: ^3.4.1
   flutter_foreground_task: ^9.2.0
-  wakelock_plus: ^1.2.8
+  wakelock_plus: ^1.4.0
   characters: ^1.4.0
   package_info_plus: ^9.0.0
   mobile_scanner: ^7.1.4  # QR/barcode scanning


### PR DESCRIPTION
## Summary
This PR aligns Android build settings with current plugin requirements by moving the app module to Java/Kotlin 17 and updating `wakelock_plus`.

## Why
`main` already uses newer plugin versions (including `package_info_plus` 9.x), but the Android app module still targets Java 11. This can cause avoidable toolchain mismatch issues.

## Changes
- `android/app/build.gradle.kts`
  - `sourceCompatibility`: `JavaVersion.VERSION_11` -> `JavaVersion.VERSION_17`
  - `targetCompatibility`: `JavaVersion.VERSION_11` -> `JavaVersion.VERSION_17`
  - `kotlinOptions.jvmTarget`: `11` -> `17`
- `pubspec.yaml`
  - `wakelock_plus`: `^1.2.8` -> `^1.4.0`

## Validation
- `flutter build apk --debug --no-pub` (pass)

## Scope / Risk
- Small, focused change (2 files).
- No app feature logic changes.
- Requires Java 17 availability in local/CI Android build environments.

## Issue
Closes #207
