### PR TITLE
Added mute channel functionality

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -2529,6 +2529,8 @@ class MeshCoreConnector extends ChangeNotifier {
     }
 
     final label = channelName ?? _channelDisplayName(channelIndex);
+    if (_appSettingsService!.isChannelMuted(label)) return;
+
     _notificationService.showChannelMessageNotification(
       channelName: label,
       message: message.text,

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Публичен канал",
   "channels_privateChannel": "Частен канал",
   "channels_editChannel": "Редактирай канал",
+  "channels_muteChannel": "Заглуши канала",
+  "channels_unmuteChannel": "Включи известията на канала",
   "channels_deleteChannel": "Изтрий канала",
   "channels_deleteChannelConfirm": "Изтрий \"{name}\"? Това не може да бъде отменено.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Öffentlicher Kanal",
   "channels_privateChannel": "Privater Kanal",
   "channels_editChannel": "Kanal bearbeiten",
+  "channels_muteChannel": "Kanal stummschalten",
+  "channels_unmuteChannel": "Kanal Stummschaltung aufheben",
   "channels_deleteChannel": "Lösche den Kanal",
   "channels_deleteChannelConfirm": "Löschen von \"{name}\"? Dies kann nicht rückgängig gemacht werden.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -352,6 +352,8 @@
   "channels_publicChannel": "Public channel",
   "channels_privateChannel": "Private channel",
   "channels_editChannel": "Edit channel",
+  "channels_muteChannel": "Mute channel",
+  "channels_unmuteChannel": "Unmute channel",
   "channels_deleteChannel": "Delete channel",
   "channels_deleteChannelConfirm": "Delete \"{name}\"? This cannot be undone.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Canal público",
   "channels_privateChannel": "Canal privado",
   "channels_editChannel": "Editar canal",
+  "channels_muteChannel": "Silenciar canal",
+  "channels_unmuteChannel": "Activar canal",
   "channels_deleteChannel": "Eliminar canal",
   "channels_deleteChannelConfirm": "Eliminar \"{name}\"? Esto no se puede deshacer.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Canal public",
   "channels_privateChannel": "Canal privé",
   "channels_editChannel": "Modifier le canal",
+  "channels_muteChannel": "Désactiver les notifications du canal",
+  "channels_unmuteChannel": "Réactiver les notifications du canal",
   "channels_deleteChannel": "Supprimer le canal",
   "channels_deleteChannelConfirm": "Supprimer {name}? Cela ne peut pas être annulé.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Canale pubblico",
   "channels_privateChannel": "Canale privato",
   "channels_editChannel": "Modifica canale",
+  "channels_muteChannel": "Silenzia canale",
+  "channels_unmuteChannel": "Attiva notifiche canale",
   "channels_deleteChannel": "Elimina canale",
   "channels_deleteChannelConfirm": "Eliminare \"{name}\"? Non può essere annullato.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1546,6 +1546,18 @@ abstract class AppLocalizations {
   /// **'Edit channel'**
   String get channels_editChannel;
 
+  /// No description provided for @channels_muteChannel.
+  ///
+  /// In en, this message translates to:
+  /// **'Mute channel'**
+  String get channels_muteChannel;
+
+  /// No description provided for @channels_unmuteChannel.
+  ///
+  /// In en, this message translates to:
+  /// **'Unmute channel'**
+  String get channels_unmuteChannel;
+
   /// No description provided for @channels_deleteChannel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -799,6 +799,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get channels_editChannel => 'Редактирай канал';
 
   @override
+  String get channels_muteChannel => 'Заглуши канала';
+
+  @override
+  String get channels_unmuteChannel => 'Включи известията на канала';
+
+  @override
   String get channels_deleteChannel => 'Изтрий канала';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -796,6 +796,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channels_editChannel => 'Kanal bearbeiten';
 
   @override
+  String get channels_muteChannel => 'Kanal stummschalten';
+
+  @override
+  String get channels_unmuteChannel => 'Kanal Stummschaltung aufheben';
+
+  @override
   String get channels_deleteChannel => 'Lösche den Kanal';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -788,6 +788,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get channels_editChannel => 'Edit channel';
 
   @override
+  String get channels_muteChannel => 'Mute channel';
+
+  @override
+  String get channels_unmuteChannel => 'Unmute channel';
+
+  @override
   String get channels_deleteChannel => 'Delete channel';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -797,6 +797,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get channels_editChannel => 'Editar canal';
 
   @override
+  String get channels_muteChannel => 'Silenciar canal';
+
+  @override
+  String get channels_unmuteChannel => 'Activar canal';
+
+  @override
   String get channels_deleteChannel => 'Eliminar canal';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -799,6 +799,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get channels_editChannel => 'Modifier le canal';
 
   @override
+  String get channels_muteChannel => 'Désactiver les notifications du canal';
+
+  @override
+  String get channels_unmuteChannel => 'Réactiver les notifications du canal';
+
+  @override
   String get channels_deleteChannel => 'Supprimer le canal';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -795,6 +795,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get channels_editChannel => 'Modifica canale';
 
   @override
+  String get channels_muteChannel => 'Silenzia canale';
+
+  @override
+  String get channels_unmuteChannel => 'Attiva notifiche canale';
+
+  @override
   String get channels_deleteChannel => 'Elimina canale';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -793,6 +793,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get channels_editChannel => 'Kanaal bewerken';
 
   @override
+  String get channels_muteChannel => 'Kanaal dempen';
+
+  @override
+  String get channels_unmuteChannel => 'Kanaal dempen opheffen';
+
+  @override
   String get channels_deleteChannel => 'Kanaal verwijderen';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -798,6 +798,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get channels_editChannel => 'Edytuj kanał';
 
   @override
+  String get channels_muteChannel => 'Wycisz kanał';
+
+  @override
+  String get channels_unmuteChannel => 'Wyłącz wyciszenie kanału';
+
+  @override
   String get channels_deleteChannel => 'Usuń kanał';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -798,6 +798,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get channels_editChannel => 'Editar canal';
 
   @override
+  String get channels_muteChannel => 'Silenciar canal';
+
+  @override
+  String get channels_unmuteChannel => 'Ativar canal';
+
+  @override
   String get channels_deleteChannel => 'Excluir canal';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -796,6 +796,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get channels_editChannel => 'Изменить канал';
 
   @override
+  String get channels_muteChannel => 'Отключить уведомления канала';
+
+  @override
+  String get channels_unmuteChannel => 'Включить уведомления канала';
+
+  @override
   String get channels_deleteChannel => 'Удалить канал';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -793,6 +793,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get channels_editChannel => 'Upraviť kanál';
 
   @override
+  String get channels_muteChannel => 'Stlmiť kanál';
+
+  @override
+  String get channels_unmuteChannel => 'Zrušiť stlmenie kanála';
+
+  @override
   String get channels_deleteChannel => 'Odstrániť kanál';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -791,6 +791,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get channels_editChannel => 'Uredi kanal';
 
   @override
+  String get channels_muteChannel => 'Utišaj kanal';
+
+  @override
+  String get channels_unmuteChannel => 'Vklopi obvestila kanala';
+
+  @override
   String get channels_deleteChannel => 'Pošlji kanal';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -787,6 +787,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get channels_editChannel => 'Redigera kanal';
 
   @override
+  String get channels_muteChannel => 'Tysta kanal';
+
+  @override
+  String get channels_unmuteChannel => 'Slå på ljud för kanal';
+
+  @override
   String get channels_deleteChannel => 'Ta bort kanal';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -794,6 +794,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get channels_editChannel => 'Редагувати канал';
 
   @override
+  String get channels_muteChannel => 'Вимкнути сповіщення каналу';
+
+  @override
+  String get channels_unmuteChannel => 'Увімкнути сповіщення каналу';
+
+  @override
   String get channels_deleteChannel => 'Видалити канал';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -756,6 +756,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get channels_editChannel => '编辑频道';
 
   @override
+  String get channels_muteChannel => '静音频道';
+
+  @override
+  String get channels_unmuteChannel => '取消静音频道';
+
+  @override
   String get channels_deleteChannel => '删除频道';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Open kanaal",
   "channels_privateChannel": "Private kanaal",
   "channels_editChannel": "Kanaal bewerken",
+  "channels_muteChannel": "Kanaal dempen",
+  "channels_unmuteChannel": "Kanaal dempen opheffen",
   "channels_deleteChannel": "Kanaal verwijderen",
   "channels_deleteChannelConfirm": "Verwijderen \"{name}\"? Dit kan niet worden teruggedraaid.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Kanał publiczny",
   "channels_privateChannel": "Prywatny kanał",
   "channels_editChannel": "Edytuj kanał",
+  "channels_muteChannel": "Wycisz kanał",
+  "channels_unmuteChannel": "Wyłącz wyciszenie kanału",
   "channels_deleteChannel": "Usuń kanał",
   "channels_deleteChannelConfirm": "Usuń \"{name}\"? Nie można tego cofnąć.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Canal público",
   "channels_privateChannel": "Canal privado",
   "channels_editChannel": "Editar canal",
+  "channels_muteChannel": "Silenciar canal",
+  "channels_unmuteChannel": "Ativar canal",
   "channels_deleteChannel": "Excluir canal",
   "channels_deleteChannelConfirm": "Excluir \"{name}\"? Não pode ser desfeito.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -226,6 +226,8 @@
   "channels_publicChannel": "Публичный канал",
   "channels_privateChannel": "Приватный канал",
   "channels_editChannel": "Изменить канал",
+  "channels_muteChannel": "Отключить уведомления канала",
+  "channels_unmuteChannel": "Включить уведомления канала",
   "channels_deleteChannel": "Удалить канал",
   "channels_deleteChannelConfirm": "Удалить \"{name}\"? Это действие нельзя отменить.",
   "channels_channelDeleted": "Канал \"{name}\" удалён",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Veľké verejne kanály",
   "channels_privateChannel": "Osobné kanál",
   "channels_editChannel": "Upraviť kanál",
+  "channels_muteChannel": "Stlmiť kanál",
+  "channels_unmuteChannel": "Zrušiť stlmenie kanála",
   "channels_deleteChannel": "Odstrániť kanál",
   "channels_deleteChannelConfirm": "Odstrániť \"{name}\"? To sa nedá zrušiť.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Javni kanal",
   "channels_privateChannel": "Zasebni kanal",
   "channels_editChannel": "Uredi kanal",
+  "channels_muteChannel": "Utišaj kanal",
+  "channels_unmuteChannel": "Vklopi obvestila kanala",
   "channels_deleteChannel": "Pošlji kanal",
   "channels_deleteChannelConfirm": "Izbrišem \"{name}\"? To se ne da povrniti.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -334,6 +334,8 @@
   "channels_publicChannel": "Allmänt kanal",
   "channels_privateChannel": "Privat kanal",
   "channels_editChannel": "Redigera kanal",
+  "channels_muteChannel": "Tysta kanal",
+  "channels_unmuteChannel": "Slå på ljud för kanal",
   "channels_deleteChannel": "Ta bort kanal",
   "channels_deleteChannelConfirm": "Radera \"{name}\"? Detta kan inte ångras.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -335,6 +335,8 @@
   "channels_publicChannel": "Публічний канал",
   "channels_privateChannel": "Приватний канал",
   "channels_editChannel": "Редагувати канал",
+  "channels_muteChannel": "Вимкнути сповіщення каналу",
+  "channels_unmuteChannel": "Увімкнути сповіщення каналу",
   "channels_deleteChannel": "Видалити канал",
   "channels_deleteChannelConfirm": "Видалити {name}? Це не можна скасувати.",
   "@channels_deleteChannelConfirm": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -342,6 +342,8 @@
   "channels_publicChannel": "公共频道",
   "channels_privateChannel": "私密频道",
   "channels_editChannel": "编辑频道",
+  "channels_muteChannel": "静音频道",
+  "channels_unmuteChannel": "取消静音频道",
   "channels_deleteChannel": "删除频道",
   "channels_deleteChannelConfirm": "Delete \"{name}\"? This cannot be undone.",
   "@channels_deleteChannelConfirm": {

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -36,6 +36,7 @@ class AppSettings {
   final Map<String, String> batteryChemistryByDeviceId;
   final Map<String, String> batteryChemistryByRepeaterId;
   final UnitSystem unitSystem;
+  final Set<String> mutedChannels;
 
   AppSettings({
     this.clearPathOnMaxRetry = false,
@@ -60,8 +61,10 @@ class AppSettings {
     Map<String, String>? batteryChemistryByDeviceId,
     Map<String, String>? batteryChemistryByRepeaterId,
     this.unitSystem = UnitSystem.metric,
+    Set<String>? mutedChannels,
   }) : batteryChemistryByDeviceId = batteryChemistryByDeviceId ?? {},
-       batteryChemistryByRepeaterId = batteryChemistryByRepeaterId ?? {};
+       batteryChemistryByRepeaterId = batteryChemistryByRepeaterId ?? {},
+       mutedChannels = mutedChannels ?? {};
 
   Map<String, dynamic> toJson() {
     return {
@@ -87,6 +90,7 @@ class AppSettings {
       'battery_chemistry_by_device_id': batteryChemistryByDeviceId,
       'battery_chemistry_by_repeater_id': batteryChemistryByRepeaterId,
       'unit_system': unitSystem.value,
+      'muted_channels': mutedChannels.toList(),
     };
   }
 
@@ -134,6 +138,11 @@ class AppSettings {
           ) ??
           {},
       unitSystem: parseUnitSystem(json['unit_system']),
+      mutedChannels:
+          ((json['muted_channels'] as List?)
+              ?.map((e) => e.toString())
+              .toSet()) ??
+          {},
     );
   }
 
@@ -160,6 +169,7 @@ class AppSettings {
     Map<String, String>? batteryChemistryByDeviceId,
     Map<String, String>? batteryChemistryByRepeaterId,
     UnitSystem? unitSystem,
+    Set<String>? mutedChannels,
   }) {
     return AppSettings(
       clearPathOnMaxRetry: clearPathOnMaxRetry ?? this.clearPathOnMaxRetry,
@@ -192,6 +202,7 @@ class AppSettings {
       batteryChemistryByRepeaterId:
           batteryChemistryByRepeaterId ?? this.batteryChemistryByRepeaterId,
       unitSystem: unitSystem ?? this.unitSystem,
+      mutedChannels: mutedChannels ?? this.mutedChannels,
     );
   }
 }

--- a/lib/screens/channels_screen.dart
+++ b/lib/screens/channels_screen.dart
@@ -9,6 +9,7 @@ import 'package:uuid/uuid.dart';
 
 import '../connector/meshcore_connector.dart';
 import '../l10n/l10n.dart';
+import '../services/app_settings_service.dart';
 import '../models/channel.dart';
 import '../models/community.dart';
 import '../storage/community_store.dart';
@@ -477,6 +478,9 @@ class _ChannelsScreenState extends State<ChannelsScreen>
     MeshCoreConnector connector,
     Channel channel,
   ) {
+    final settingsService = context.read<AppSettingsService>();
+    final isMuted = settingsService.isChannelMuted(channel.name);
+
     showModalBottomSheet(
       context: context,
       builder: (context) => SafeArea(
@@ -491,6 +495,26 @@ class _ChannelsScreenState extends State<ChannelsScreen>
                 await Future.delayed(const Duration(milliseconds: 100));
                 if (context.mounted) {
                   _showEditChannelDialog(context, connector, channel);
+                }
+              },
+            ),
+            ListTile(
+              leading: Icon(
+                isMuted
+                    ? Icons.notifications_outlined
+                    : Icons.notifications_off_outlined,
+              ),
+              title: Text(
+                isMuted
+                    ? context.l10n.channels_unmuteChannel
+                    : context.l10n.channels_muteChannel,
+              ),
+              onTap: () async {
+                Navigator.pop(context);
+                if (isMuted) {
+                  await settingsService.unmuteChannel(channel.name);
+                } else {
+                  await settingsService.muteChannel(channel.name);
                 }
               },
             ),

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -155,4 +155,19 @@ class AppSettingsService extends ChangeNotifier {
   Future<void> setUnitSystem(UnitSystem value) async {
     await updateSettings(_settings.copyWith(unitSystem: value));
   }
+
+  bool isChannelMuted(String channelName) {
+    return _settings.mutedChannels.contains(channelName);
+  }
+
+  Future<void> muteChannel(String channelName) async {
+    final updated = Set<String>.from(_settings.mutedChannels)..add(channelName);
+    await updateSettings(_settings.copyWith(mutedChannels: updated));
+  }
+
+  Future<void> unmuteChannel(String channelName) async {
+    final updated = Set<String>.from(_settings.mutedChannels)
+      ..remove(channelName);
+    await updateSettings(_settings.copyWith(mutedChannels: updated));
+  }
 }


### PR DESCRIPTION
I needed to mute channels sometimes, so I added this functionality. 

It adds entry between "Edit channel" and "Delete channel" -> "Mute channel"  / "Unmute channel"

The only thing it does is stops notifications for the muted channels. The badge is untouched.