### PR TITLE
Better french translations

### DIFF
--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -262,7 +262,7 @@
     }
   },
   "contacts_manageRepeater": "Gérer le répéteur",
-  "contacts_roomLogin": "Connexion Salle",
+  "contacts_roomLogin": "Connexion Room Server",
   "contacts_openChat": "Ouverture du Chat",
   "contacts_editGroup": "Modifier le groupe",
   "contacts_deleteGroup": "Supprimer le groupe",
@@ -798,7 +798,7 @@
   "dialog_disconnect": "Déconnecter",
   "dialog_disconnectConfirm": "Êtes-vous sûr de vouloir vous déconnecter de cet appareil ?",
   "login_repeaterLogin": "Connexion au répéteur",
-  "login_roomLogin": "Connexion Salle",
+  "login_roomLogin": "Connexion Room Server",
   "login_password": "Mot de passe",
   "login_enterPassword": "Entrez votre mot de passe",
   "login_savePassword": "Sauvegarder le mot de passe",
@@ -1393,7 +1393,7 @@
   "settings_locationIntervalSec": "Intervalle de mise-à-jour du GPS (Secondes)",
   "settings_locationIntervalInvalid": "L'intervalle doit être compris entre 60 et 86400 secondes.",
   "contacts_manageRoom": "Gérer le Room Server",
-  "room_management": "Administración del Servidor de Habitación",
+  "room_management": "Administrattion Room Server",
   "@community_joinConfirmation": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -696,7 +696,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get contacts_manageRoom => 'Gérer le Room Server';
 
   @override
-  String get contacts_roomLogin => 'Connexion Salle';
+  String get contacts_roomLogin => 'Connexion Room Server';
 
   @override
   String get contacts_openChat => 'Ouverture du Chat';
@@ -1559,7 +1559,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get login_repeaterLogin => 'Connexion au répéteur';
 
   @override
-  String get login_roomLogin => 'Connexion Salle';
+  String get login_roomLogin => 'Connexion Room Server';
 
   @override
   String get login_password => 'Mot de passe';
@@ -1684,7 +1684,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get repeater_management => 'Gestion des répéteurs';
 
   @override
-  String get room_management => 'Administración del Servidor de Habitación';
+  String get room_management => 'Administrattion Room Server';
 
   @override
   String get repeater_managementTools => 'Outils de Gestion';


### PR DESCRIPTION
More translations.

I noticed some words are missing, for example when a new repeater or contact is discovered, the notification is (in french):
Nouveau Repeater découvert
Nouveau Chat découvert

I looked in the translation file and the translation source is "New {contactType} discovered"
but contactType is not translatable.
