### PR TITLE
Add timestamp-based last-read tracking and unread divider markers

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -413,16 +413,15 @@ class MeshCoreConnector extends ChangeNotifier {
   ) {
     if (orderedMessages.isEmpty) return null;
 
+    final unreadCount = getUnreadCountForContactKey(contactKeyHex);
     final marker = _contactLastReadTs[contactKeyHex];
     if (marker != null) {
       final markerIndex = orderedMessages.indexWhere(
         (m) => m.timestamp.millisecondsSinceEpoch > marker,
       );
       if (markerIndex >= 0) return markerIndex;
-      return null;
     }
 
-    final unreadCount = getUnreadCountForContactKey(contactKeyHex);
     if (unreadCount <= 0) return null;
     if (unreadCount >= orderedMessages.length) return 0;
     return orderedMessages.length - unreadCount;
@@ -434,16 +433,15 @@ class MeshCoreConnector extends ChangeNotifier {
   ) {
     if (orderedMessages.isEmpty) return null;
 
+    final unreadCount = getUnreadCountForChannelIndex(channelIndex);
     final marker = _channelLastReadTs[channelIndex];
     if (marker != null) {
       final markerIndex = orderedMessages.indexWhere(
         (m) => m.timestamp.millisecondsSinceEpoch > marker,
       );
       if (markerIndex >= 0) return markerIndex;
-      return null;
     }
 
-    final unreadCount = getUnreadCountForChannelIndex(channelIndex);
     if (unreadCount <= 0) return null;
     if (unreadCount >= orderedMessages.length) return 0;
     return orderedMessages.length - unreadCount;

--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -204,6 +204,8 @@ class MeshCoreConnector extends ChangeNotifier {
   final Map<String, bool> _contactSmazEnabled = {};
   final Set<String> _knownContactKeys = {};
   final Map<String, int> _contactUnreadCount = {};
+  final Map<String, int> _contactLastReadTs = {};
+  final Map<int, int> _channelLastReadTs = {};
   final Map<String, RepeaterBatterySnapshot> _repeaterBatterySnapshots = {};
   bool _unreadStateLoaded = false;
   final Map<String, _RepeaterAckContext> _pendingRepeaterAcks = {};
@@ -386,6 +388,11 @@ class MeshCoreConnector extends ChangeNotifier {
     return _contactUnreadCount[contactKeyHex] ?? 0;
   }
 
+  int? contactLastReadTimestamp(String contactKeyHex) {
+    if (!_unreadStateLoaded) return null;
+    return _contactLastReadTs[contactKeyHex];
+  }
+
   int getUnreadCountForChannel(Channel channel) {
     return getUnreadCountForChannelIndex(channel.index);
   }
@@ -393,6 +400,53 @@ class MeshCoreConnector extends ChangeNotifier {
   int getUnreadCountForChannelIndex(int channelIndex) {
     if (!_unreadStateLoaded) return 0;
     return _findChannelByIndex(channelIndex)?.unreadCount ?? 0;
+  }
+
+  int? channelLastReadTimestamp(int channelIndex) {
+    if (!_unreadStateLoaded) return null;
+    return _channelLastReadTs[channelIndex];
+  }
+
+  int? firstUnreadContactIndex(
+    String contactKeyHex,
+    List<Message> orderedMessages,
+  ) {
+    if (orderedMessages.isEmpty) return null;
+
+    final marker = _contactLastReadTs[contactKeyHex];
+    if (marker != null) {
+      final markerIndex = orderedMessages.indexWhere(
+        (m) => m.timestamp.millisecondsSinceEpoch > marker,
+      );
+      if (markerIndex >= 0) return markerIndex;
+      return null;
+    }
+
+    final unreadCount = getUnreadCountForContactKey(contactKeyHex);
+    if (unreadCount <= 0) return null;
+    if (unreadCount >= orderedMessages.length) return 0;
+    return orderedMessages.length - unreadCount;
+  }
+
+  int? firstUnreadChannelIndex(
+    int channelIndex,
+    List<ChannelMessage> orderedMessages,
+  ) {
+    if (orderedMessages.isEmpty) return null;
+
+    final marker = _channelLastReadTs[channelIndex];
+    if (marker != null) {
+      final markerIndex = orderedMessages.indexWhere(
+        (m) => m.timestamp.millisecondsSinceEpoch > marker,
+      );
+      if (markerIndex >= 0) return markerIndex;
+      return null;
+    }
+
+    final unreadCount = getUnreadCountForChannelIndex(channelIndex);
+    if (unreadCount <= 0) return null;
+    if (unreadCount >= orderedMessages.length) return 0;
+    return orderedMessages.length - unreadCount;
   }
 
   int getTotalUnreadCount() {
@@ -425,6 +479,12 @@ class MeshCoreConnector extends ChangeNotifier {
     _contactUnreadCount
       ..clear()
       ..addAll(await _unreadStore.loadContactUnreadCount());
+    _contactLastReadTs
+      ..clear()
+      ..addAll(await _unreadStore.loadContactLastReadTs());
+    _channelLastReadTs
+      ..clear()
+      ..addAll(await _unreadStore.loadChannelLastReadTs());
     _unreadStateLoaded = true;
     notifyListeners();
   }
@@ -454,7 +514,12 @@ class MeshCoreConnector extends ChangeNotifier {
 
   void markContactRead(String contactKeyHex) {
     if (!_shouldTrackUnreadForContactKey(contactKeyHex)) return;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    _contactLastReadTs[contactKeyHex] = nowMs;
     final previousCount = _contactUnreadCount[contactKeyHex] ?? 0;
+    _unreadStore.saveContactLastReadTs(
+      Map<String, int>.from(_contactLastReadTs),
+    );
     if (previousCount > 0) {
       _contactUnreadCount[contactKeyHex] = 0;
       _appDebugLogService?.info(
@@ -469,6 +534,8 @@ class MeshCoreConnector extends ChangeNotifier {
   }
 
   void markChannelRead(int channelIndex) {
+    _channelLastReadTs[channelIndex] = DateTime.now().millisecondsSinceEpoch;
+    _unreadStore.saveChannelLastReadTs(Map<int, int>.from(_channelLastReadTs));
     final channel = _findChannelByIndex(channelIndex);
     if (channel != null && channel.unreadCount > 0) {
       final previousCount = channel.unreadCount;
@@ -1496,8 +1563,12 @@ class MeshCoreConnector extends ChangeNotifier {
     _conversations.remove(contact.publicKeyHex);
     _loadedConversationKeys.remove(contact.publicKeyHex);
     _contactUnreadCount.remove(contact.publicKeyHex);
+    _contactLastReadTs.remove(contact.publicKeyHex);
     _unreadStore.saveContactUnreadCount(
       Map<String, int>.from(_contactUnreadCount),
+    );
+    _unreadStore.saveContactLastReadTs(
+      Map<String, int>.from(_contactLastReadTs),
     );
     _messageStore.clearMessages(contact.publicKeyHex);
     notifyListeners();
@@ -1815,6 +1886,8 @@ class MeshCoreConnector extends ChangeNotifier {
     await _channelMessageStore.clearChannelMessages(index);
     // Clear in-memory messages for this channel
     _channelMessages.remove(index);
+    _channelLastReadTs.remove(index);
+    _unreadStore.saveChannelLastReadTs(Map<int, int>.from(_channelLastReadTs));
     // Refresh channels after deleting
     await getChannels(force: true);
   }

--- a/lib/screens/channel_chat_screen.dart
+++ b/lib/screens/channel_chat_screen.dart
@@ -26,6 +26,7 @@ import '../widgets/gif_message.dart';
 import '../widgets/jump_to_bottom_button.dart';
 import '../widgets/gif_picker.dart';
 import '../widgets/message_status_icon.dart';
+import '../widgets/unread_marker_divider.dart';
 import 'channel_message_path_screen.dart';
 import 'map_screen.dart';
 
@@ -209,6 +210,14 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                     );
                   }
 
+                  final firstUnreadIndex = connector.firstUnreadChannelIndex(
+                    widget.channel.index,
+                    messages,
+                  );
+                  final unreadMarkerReversedIndex = firstUnreadIndex == null
+                      ? null
+                      : (messages.length - 1 - firstUnreadIndex);
+
                   // Reverse messages so newest appear at bottom with reverse: true
                   final reversedMessages = messages.reversed.toList();
                   final itemCount =
@@ -245,10 +254,13 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                             }
                             final messageIndex = index;
                             final message = reversedMessages[messageIndex];
+                            final showUnreadMarker =
+                                unreadMarkerReversedIndex != null &&
+                                messageIndex == unreadMarkerReversedIndex;
                             if (!_messageKeys.containsKey(message.messageId)) {
                               _messageKeys[message.messageId] = GlobalKey();
                             }
-                            return Container(
+                            final messageWidget = Container(
                               key: _messageKeys[message.messageId]!,
                               child: Builder(
                                 builder: (context) {
@@ -262,6 +274,20 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                                   );
                                 },
                               ),
+                            );
+
+                            if (!showUnreadMarker) {
+                              return messageWidget;
+                            }
+
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                UnreadMarkerDivider(
+                                  timestamp: message.timestamp,
+                                ),
+                                messageWidget,
+                              ],
                             );
                           },
                         ),

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -34,6 +34,7 @@ import '../widgets/gif_message.dart';
 import '../widgets/jump_to_bottom_button.dart';
 import '../widgets/gif_picker.dart';
 import '../widgets/path_selection_dialog.dart';
+import '../widgets/unread_marker_divider.dart';
 import '../utils/app_logger.dart';
 import '../l10n/l10n.dart';
 
@@ -263,6 +264,14 @@ class _ChatScreenState extends State<ChatScreen> {
     List<Message> messages,
     MeshCoreConnector connector,
   ) {
+    final firstUnreadIndex = connector.firstUnreadContactIndex(
+      widget.contact.publicKeyHex,
+      messages,
+    );
+    final unreadMarkerReversedIndex = firstUnreadIndex == null
+        ? null
+        : (messages.length - 1 - firstUnreadIndex);
+
     // Reverse messages so newest appear at bottom with reverse: true
     final reversedMessages = messages.reversed.toList();
     final itemCount = reversedMessages.length + (_isLoadingOlder ? 1 : 0);
@@ -309,12 +318,16 @@ class _ChatScreenState extends State<ChatScreen> {
                 .toUpperCase();
           }
 
+          final showUnreadMarker =
+              unreadMarkerReversedIndex != null &&
+              messageIndex == unreadMarkerReversedIndex;
+
           return Builder(
             builder: (context) {
               final textScale = context.select<ChatTextScaleService, double>(
                 (service) => service.scale,
               );
-              return _MessageBubble(
+              final bubble = _MessageBubble(
                 message: message,
                 senderName: widget.contact.type == advTypeRoom
                     ? "${contact.name} [$fourByteHex]"
@@ -323,6 +336,14 @@ class _ChatScreenState extends State<ChatScreen> {
                 textScale: textScale,
                 onTap: () => _openMessagePath(message, contact),
                 onLongPress: () => _showMessageActions(message, contact),
+              );
+              if (!showUnreadMarker) return bubble;
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  UnreadMarkerDivider(timestamp: message.timestamp),
+                  bubble,
+                ],
               );
             },
           );

--- a/lib/storage/unread_store.dart
+++ b/lib/storage/unread_store.dart
@@ -6,17 +6,25 @@ import 'prefs_manager.dart';
 /// Storage for unread message tracking with debounced writes to reduce I/O.
 class UnreadStore {
   static const String _contactUnreadCountKey = 'contact_unread_count';
+  static const String _contactLastReadTsKey = 'contact_last_read_ts';
+  static const String _channelLastReadTsKey = 'channel_last_read_ts';
 
   // Debounce timers to batch rapid writes
   Timer? _contactUnreadSaveTimer;
+  Timer? _contactLastReadSaveTimer;
+  Timer? _channelLastReadSaveTimer;
   static const Duration _saveDebounceDuration = Duration(milliseconds: 500);
 
   // Pending write data
   Map<String, int>? _pendingContactUnreadCount;
+  Map<String, int>? _pendingContactLastReadTs;
+  Map<int, int>? _pendingChannelLastReadTs;
 
   /// Dispose timers when no longer needed
   void dispose() {
     _contactUnreadSaveTimer?.cancel();
+    _contactLastReadSaveTimer?.cancel();
+    _channelLastReadSaveTimer?.cancel();
   }
 
   Future<Map<String, int>> loadContactUnreadCount() async {
@@ -27,6 +35,38 @@ class UnreadStore {
     try {
       final json = jsonDecode(jsonStr) as Map<String, dynamic>;
       return json.map((key, value) => MapEntry(key, value as int));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<Map<String, int>> loadContactLastReadTs() async {
+    final prefs = PrefsManager.instance;
+    final jsonStr = prefs.getString(_contactLastReadTsKey);
+    if (jsonStr == null) return {};
+
+    try {
+      final json = jsonDecode(jsonStr) as Map<String, dynamic>;
+      return json.map((key, value) => MapEntry(key, value as int));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<Map<int, int>> loadChannelLastReadTs() async {
+    final prefs = PrefsManager.instance;
+    final jsonStr = prefs.getString(_channelLastReadTsKey);
+    if (jsonStr == null) return {};
+
+    try {
+      final json = jsonDecode(jsonStr) as Map<String, dynamic>;
+      final parsed = <int, int>{};
+      for (final entry in json.entries) {
+        final key = int.tryParse(entry.key);
+        if (key == null) continue;
+        parsed[key] = entry.value as int;
+      }
+      return parsed;
     } catch (_) {
       return {};
     }
@@ -44,6 +84,28 @@ class UnreadStore {
     });
   }
 
+  void saveContactLastReadTs(Map<String, int> markers) {
+    _pendingContactLastReadTs = markers;
+    _contactLastReadSaveTimer?.cancel();
+
+    _contactLastReadSaveTimer = Timer(_saveDebounceDuration, () async {
+      if (_pendingContactLastReadTs != null) {
+        await _flushContactLastReadTs();
+      }
+    });
+  }
+
+  void saveChannelLastReadTs(Map<int, int> markers) {
+    _pendingChannelLastReadTs = markers;
+    _channelLastReadSaveTimer?.cancel();
+
+    _channelLastReadSaveTimer = Timer(_saveDebounceDuration, () async {
+      if (_pendingChannelLastReadTs != null) {
+        await _flushChannelLastReadTs();
+      }
+    });
+  }
+
   Future<void> _flushContactUnreadCount() async {
     if (_pendingContactUnreadCount == null) return;
 
@@ -53,9 +115,35 @@ class UnreadStore {
     _pendingContactUnreadCount = null;
   }
 
+  Future<void> _flushContactLastReadTs() async {
+    if (_pendingContactLastReadTs == null) return;
+
+    final prefs = PrefsManager.instance;
+    final jsonStr = jsonEncode(_pendingContactLastReadTs);
+    await prefs.setString(_contactLastReadTsKey, jsonStr);
+    _pendingContactLastReadTs = null;
+  }
+
+  Future<void> _flushChannelLastReadTs() async {
+    if (_pendingChannelLastReadTs == null) return;
+
+    final prefs = PrefsManager.instance;
+    final data = <String, int>{};
+    for (final entry in _pendingChannelLastReadTs!.entries) {
+      data[entry.key.toString()] = entry.value;
+    }
+    final jsonStr = jsonEncode(data);
+    await prefs.setString(_channelLastReadTsKey, jsonStr);
+    _pendingChannelLastReadTs = null;
+  }
+
   /// Immediately flush pending writes (call before app termination or disposal)
   Future<void> flush() async {
     _contactUnreadSaveTimer?.cancel();
+    _contactLastReadSaveTimer?.cancel();
+    _channelLastReadSaveTimer?.cancel();
     await _flushContactUnreadCount();
+    await _flushContactLastReadTs();
+    await _flushChannelLastReadTs();
   }
 }

--- a/lib/widgets/unread_marker_divider.dart
+++ b/lib/widgets/unread_marker_divider.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class UnreadMarkerDivider extends StatelessWidget {
+  final DateTime timestamp;
+
+  const UnreadMarkerDivider({super.key, required this.timestamp});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final markerColor = theme.colorScheme.error.withValues(alpha: 0.7);
+    final dateLabel = MaterialLocalizations.of(
+      context,
+    ).formatMediumDate(timestamp);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 8, 4, 10),
+      child: Row(
+        children: [
+          Expanded(child: Divider(height: 1, thickness: 1, color: markerColor)),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              dateLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: markerColor,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(child: Divider(height: 1, thickness: 1, color: markerColor)),
+          const SizedBox(width: 6),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.error,
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: Icon(
+              Icons.fiber_new,
+              size: 14,
+              color: theme.colorScheme.onError,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds timestamp-based last-read tracking for contacts/channels and uses it to place an in-chat unread divider for DM and channel threads.

## Why
Unread counts alone are not stable for locating the unread boundary after list mutations.
Timestamp markers provide deterministic first-unread positioning while preserving count-based fallback behavior.

## Changes
- `lib/storage/unread_store.dart`
  - Persist/debounce contact and channel last-read timestamps.
- `lib/connector/meshcore_connector.dart`
  - Store/load in-memory last-read maps.
  - Add timestamp getters:
    - `contactLastReadTimestamp(...)`
    - `channelLastReadTimestamp(...)`
  - Add first-unread helpers with fallback:
    - `firstUnreadContactIndex(...)`
    - `firstUnreadChannelIndex(...)`
  - Update read-mark APIs to persist timestamps.
  - Remove marker state when deleting contacts/channels.
- `lib/screens/chat_screen.dart`
  - Render unread divider for DM threads.
- `lib/screens/channel_chat_screen.dart`
  - Render unread divider for channel threads.
- `lib/widgets/unread_marker_divider.dart`
  - Shared unread divider widget.

## Behavior Notes
- Divider placement prefers timestamp markers.
- If no marker resolves to a newer message, logic falls back to unread-count behavior.
- Existing unread counters remain intact.

## Validation
- `dart format` on touched files
- `flutter analyze lib/connector/meshcore_connector.dart lib/storage/unread_store.dart lib/screens/chat_screen.dart lib/screens/channel_chat_screen.dart lib/widgets/unread_marker_divider.dart` (pass)

## Issue
Part of #73
