### PR TITLE
blob upload for android build, so app is available for testing.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: flutter pub get
       - run: flutter build apk --release --no-pub
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: build/app/outputs/flutter-apk/app-release.apk
 
   ios:
     runs-on: macos-latest


### PR DESCRIPTION
Upload to blob storage for easy test of android version.

If you run the build workflow, the APK file gets stored and is not lost. Therefore it is downloadable and can be tested.
It gets build anyway, so why not use this build too test? At least for the android version.

> made new Pull-Request, since other changes were unwillingly submitted to other pull-request.