### PR TITLE
Allow search for prefix as Displayed in contact list

### DIFF
--- a/lib/utils/contact_search.dart
+++ b/lib/utils/contact_search.dart
@@ -16,11 +16,11 @@ bool matchesContactQuery(Contact contact, String query) {
 
 String? _extractHexPrefix(String query) {
   var cleaned = query;
-  if (cleaned.startsWith('0x')) {
-    cleaned = cleaned.substring(2);
-  }
   if (cleaned.startsWith('<')) {
     cleaned = cleaned.substring(1).replaceAll(">", "");
+  }
+  if (cleaned.startsWith('0x')) {
+    cleaned = cleaned.substring(2);
   }
   cleaned = cleaned.replaceAll(' ', '');
   if (cleaned.length < 2) return null;


### PR DESCRIPTION
I found that I can search for a prefix with "0x..", but only after analyzing the code.
For example when I want to find a repeater, from which I know it begins with "90". (Not 90 somewhere in the name or middle of the key.)
So I propose this small change to enable entry in the format the prefix is also Displayed in the Contact list via "<90". (Its also the way I am used from Liams app)
I hope it makes the search more intuitive.

Sincerely Eric