### PR TITLE
use location to match snr-indicator contacts

### DIFF
--- a/lib/utils/location_utils.dart
+++ b/lib/utils/location_utils.dart
@@ -7,7 +7,7 @@ Contact? selectBestRepeaterContactForPrefix(
   List<Contact> contacts,
   int pubkeyFirstByte, {
   LatLng? searchPoint,
-  bool preferFavorites = false,
+  bool? preferFavorites = false,
 }) {
   final candidates = contacts
       .where(

--- a/lib/widgets/snr_indicator.dart
+++ b/lib/widgets/snr_indicator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:latlong2/latlong.dart';
 
 import '../connector/meshcore_connector.dart';
 import '../l10n/l10n.dart';
@@ -162,10 +163,21 @@ class _SNRIndicatorState extends State<SNRIndicator> {
                   widget.connector.currentSf,
                 );
 
+                final selfLat = widget.connector.selfLatitude;
+                final selfLon = widget.connector.selfLongitude;
+
+                LatLng? selfPoint;
+                if (selfLat != null && selfLon != null) {
+                  selfPoint = LatLng(selfLat, selfLon);
+                }
+
                 final contact = selectBestRepeaterContactForPrefix(
                   widget.connector.contacts,
                   repeater.pubkeyFirstByte,
+                  searchPoint: selfPoint,
+                  preferFavorites: true,
                 );
+
                 final name = contact?.name;
 
                 return Column(


### PR DESCRIPTION
Hi there,

as I wrote, I am not familiar with flutter programming, therefore I would like some feedback on this pull-request.
Then I used a bit of vibecoding, but only so I understood the made changes.

This Pull-request addresses the first part of my Ideas in Issue #255 to use location for the SNR-Indicator.
Instead of using the oldest matching prefix, I now use first contacts which have location data.
And on them if I have multiple matches (I had one), I use the nearest.
And if there are no contacts with location (maybe because its a direct connection to another companion) it should use the last-seen of the prefix matches.

Best regards
Eric