### PR TITLE
fix: Chrome connect screen and handshake

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -686,6 +686,11 @@ class MeshCoreConnector extends ChangeNotifier {
   }) async {
     if (_state == MeshCoreConnectionState.scanning) return;
 
+    if (kIsWeb) {
+      await _startScanWeb(timeout: timeout);
+      return;
+    }
+
     _scanResults.clear();
     _setState(MeshCoreConnectionState.scanning);
 
@@ -730,6 +735,69 @@ class MeshCoreConnector extends ChangeNotifier {
 
     await Future.delayed(timeout);
     await stopScan();
+  }
+
+  Future<void> _startScanWeb({
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    _scanResults.clear();
+    _setState(MeshCoreConnectionState.scanning);
+
+    // Ensure any previous scan is fully stopped
+    await FlutterBluePlus.stopScan();
+    await _scanSubscription?.cancel();
+
+    final completer = Completer<void>();
+    bool handled = false;
+
+    _scanSubscription = FlutterBluePlus.scanResults.listen((results) async {
+      _scanResults
+        ..clear()
+        ..addAll(results);
+      notifyListeners();
+
+      if (results.isEmpty || handled || completer.isCompleted) {
+        return;
+      }
+      handled = true;
+
+      final result = results.first;
+      final name = result.device.platformName.isNotEmpty
+          ? result.device.platformName
+          : result.advertisementData.advName;
+
+      try {
+        await connect(result.device, displayName: name);
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      } catch (e) {
+        debugPrint('Web scan auto-connect failed: $e');
+        if (_state == MeshCoreConnectionState.scanning) {
+          await stopScan();
+        }
+        if (!completer.isCompleted) {
+          completer.completeError(e);
+        }
+      }
+    });
+
+    try {
+      await FlutterBluePlus.startScan(
+        withServices: [Guid(MeshCoreUuids.service)],
+        withKeywords: ["MeshCore-", "Whisper-"],
+        webOptionalServices: [Guid(MeshCoreUuids.service)],
+        timeout: timeout,
+        androidScanMode: AndroidScanMode.lowLatency,
+      );
+    } catch (e) {
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
+      rethrow;
+    }
+
+    await completer.future;
   }
 
   Future<void> stopScan() async {
@@ -850,7 +918,13 @@ class MeshCoreConnector extends ChangeNotifier {
       unawaited(getChannels());
     } catch (e) {
       debugPrint("Connection error: $e");
-      await disconnect(manual: false);
+      // On Web, avoid auto-reconnect loops on connection failure so the
+      // caller can surface a one-shot error and let the user retry.
+      if (kIsWeb) {
+        await disconnect(manual: true);
+      } else {
+        await disconnect(manual: false);
+      }
       rethrow;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -192,8 +192,8 @@ class MeshCoreApp extends StatelessWidget {
             },
             home: PlatformInfo.isWeb
                 ? (PlatformInfo.isChrome
-                    ? const WebScannerScreen()
-                    : const ChromeRequiredScreen())
+                      ? const WebScannerScreen()
+                      : const ChromeRequiredScreen())
                 : const ScannerScreen(),
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,11 +4,10 @@ import 'package:flutter/foundation.dart';
 import 'l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
-import 'screens/chrome_required_screen.dart';
-import 'utils/platform_info.dart';
-
 import 'connector/meshcore_connector.dart';
+import 'screens/chrome_required_screen.dart';
 import 'screens/scanner_screen.dart';
+import 'screens/web_scanner_screen.dart';
 import 'services/storage_service.dart';
 import 'services/message_retry_service.dart';
 import 'services/path_history_service.dart';
@@ -21,6 +20,7 @@ import 'services/map_tile_cache_service.dart';
 import 'services/chat_text_scale_service.dart';
 import 'storage/prefs_manager.dart';
 import 'utils/app_logger.dart';
+import 'utils/platform_info.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -190,8 +190,10 @@ class MeshCoreApp extends StatelessWidget {
               NotificationService().setLocale(locale);
               return child ?? const SizedBox.shrink();
             },
-            home: (PlatformInfo.isWeb && !PlatformInfo.isChrome)
-                ? const ChromeRequiredScreen()
+            home: PlatformInfo.isWeb
+                ? (PlatformInfo.isChrome
+                    ? const WebScannerScreen()
+                    : const ChromeRequiredScreen())
                 : const ScannerScreen(),
           );
         },

--- a/lib/screens/scanner_screen.dart
+++ b/lib/screens/scanner_screen.dart
@@ -109,7 +109,8 @@ class _ScannerScreenState extends State<ScannerScreen> {
           final isBluetoothOff = _bluetoothState == BluetoothAdapterState.off;
 
           if (PlatformInfo.isWeb) {
-            final isBusy = connector.state != MeshCoreConnectionState.disconnected;
+            final isBusy =
+                connector.state != MeshCoreConnectionState.disconnected;
 
             return FloatingActionButton.extended(
               onPressed: isBusy

--- a/lib/screens/scanner_screen.dart
+++ b/lib/screens/scanner_screen.dart
@@ -86,14 +86,19 @@ class _ScannerScreenState extends State<ScannerScreen> {
             return Column(
               children: [
                 // Bluetooth off warning
-                if (_bluetoothState == BluetoothAdapterState.off)
+                if (_bluetoothState == BluetoothAdapterState.off &&
+                    !PlatformInfo.isWeb)
                   _bluetoothOffWarning(context),
 
                 // Status bar
                 _buildStatusBar(context, connector),
 
                 // Device list
-                Expanded(child: _buildDeviceList(context, connector)),
+                Expanded(
+                  child: PlatformInfo.isWeb
+                      ? _buildChromeConnectPlaceholder(context)
+                      : _buildDeviceList(context, connector),
+                ),
               ],
             );
           },
@@ -101,9 +106,28 @@ class _ScannerScreenState extends State<ScannerScreen> {
       ),
       floatingActionButton: Consumer<MeshCoreConnector>(
         builder: (context, connector, child) {
+          final isBluetoothOff = _bluetoothState == BluetoothAdapterState.off;
+
+          if (PlatformInfo.isWeb) {
+            final isBusy = connector.state != MeshCoreConnectionState.disconnected;
+
+            return FloatingActionButton.extended(
+              onPressed: isBusy
+                  ? null
+                  : () {
+                      unawaited(
+                        connector.startScan().catchError((e) {
+                          debugPrint("Scanner screen web startScan error: $e");
+                        }),
+                      );
+                    },
+              icon: const Icon(Icons.bluetooth),
+              label: Text(context.l10n.common_connect),
+            );
+          }
+
           final isScanning =
               connector.state == MeshCoreConnectionState.scanning;
-          final isBluetoothOff = _bluetoothState == BluetoothAdapterState.off;
 
           return FloatingActionButton.extended(
             onPressed: isBluetoothOff
@@ -179,6 +203,23 @@ class _ScannerScreenState extends State<ScannerScreen> {
           Text(
             statusText,
             style: TextStyle(color: statusColor, fontWeight: FontWeight.w500),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChromeConnectPlaceholder(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.bluetooth, size: 64, color: Colors.grey[400]),
+          const SizedBox(height: 16),
+          Text(
+            context.l10n.scanner_tapToScan,
+            style: TextStyle(fontSize: 16, color: Colors.grey[600]),
+            textAlign: TextAlign.center,
           ),
         ],
       ),

--- a/lib/screens/web_scanner_screen.dart
+++ b/lib/screens/web_scanner_screen.dart
@@ -87,18 +87,20 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
                       onPressed: isBusy
                           ? null
                           : () {
+                              final l10n = context.l10n;
+                              final scaffoldMessenger = ScaffoldMessenger.of(
+                                context,
+                              );
                               unawaited(
                                 connector.startScan().catchError((e) {
                                   if (!mounted) return;
                                   final msg = e.toString().contains('Timed out')
                                       ? 'Connection timed out. Please try again.'
                                       : e.toString();
-                                  ScaffoldMessenger.of(context).showSnackBar(
+                                  scaffoldMessenger.showSnackBar(
                                     SnackBar(
                                       content: Text(
-                                        context.l10n.scanner_connectionFailed(
-                                          msg,
-                                        ),
+                                        l10n.scanner_connectionFailed(msg),
                                       ),
                                       backgroundColor: Colors.red,
                                     ),

--- a/lib/screens/web_scanner_screen.dart
+++ b/lib/screens/web_scanner_screen.dart
@@ -63,15 +63,15 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
             builder: (context, connector, child) {
               final isBusy =
                   connector.state == MeshCoreConnectionState.scanning ||
-                      connector.state == MeshCoreConnectionState.connecting ||
-                      connector.state == MeshCoreConnectionState.connected ||
-                      connector.state ==
-                          MeshCoreConnectionState.disconnecting;
+                  connector.state == MeshCoreConnectionState.connecting ||
+                  connector.state == MeshCoreConnectionState.connected ||
+                  connector.state == MeshCoreConnectionState.disconnecting;
 
               String? statusLabel;
               if (connector.state == MeshCoreConnectionState.scanning) {
                 statusLabel = context.l10n.scanner_scanning;
-              } else if (connector.state == MeshCoreConnectionState.connecting ||
+              } else if (connector.state ==
+                      MeshCoreConnectionState.connecting ||
                   connector.state == MeshCoreConnectionState.disconnecting) {
                 statusLabel = context.l10n.scanner_connecting;
               }
@@ -79,11 +79,7 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
               return Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(
-                    Icons.bluetooth,
-                    size: 80,
-                    color: Colors.grey[400],
-                  ),
+                  Icon(Icons.bluetooth, size: 80, color: Colors.grey[400]),
                   const SizedBox(height: 24),
                   SizedBox(
                     width: 260,
@@ -100,7 +96,9 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
                                   ScaffoldMessenger.of(context).showSnackBar(
                                     SnackBar(
                                       content: Text(
-                                        context.l10n.scanner_connectionFailed(msg),
+                                        context.l10n.scanner_connectionFailed(
+                                          msg,
+                                        ),
                                       ),
                                       backgroundColor: Colors.red,
                                     ),
@@ -108,7 +106,10 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
                                 }),
                               );
                             },
-                      icon: isBusy && connector.state == MeshCoreConnectionState.connecting
+                      icon:
+                          isBusy &&
+                              connector.state ==
+                                  MeshCoreConnectionState.connecting
                           ? const SizedBox(
                               width: 20,
                               height: 20,
@@ -131,10 +132,7 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
                     const SizedBox(height: 16),
                     Text(
                       statusLabel,
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: Colors.grey[600],
-                      ),
+                      style: TextStyle(fontSize: 14, color: Colors.grey[600]),
                     ),
                   ],
                 ],
@@ -146,4 +144,3 @@ class _WebScannerScreenState extends State<WebScannerScreen> {
     );
   }
 }
-

--- a/lib/screens/web_scanner_screen.dart
+++ b/lib/screens/web_scanner_screen.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../connector/meshcore_connector.dart';
+import '../l10n/l10n.dart';
+import '../widgets/adaptive_app_bar_title.dart';
+import 'contacts_screen.dart';
+
+class WebScannerScreen extends StatefulWidget {
+  const WebScannerScreen({super.key});
+
+  @override
+  State<WebScannerScreen> createState() => _WebScannerScreenState();
+}
+
+class _WebScannerScreenState extends State<WebScannerScreen> {
+  bool _changedNavigation = false;
+  late final VoidCallback _connectionListener;
+
+  @override
+  void initState() {
+    super.initState();
+    final connector = Provider.of<MeshCoreConnector>(context, listen: false);
+
+    _connectionListener = () {
+      if (connector.state == MeshCoreConnectionState.disconnected) {
+        _changedNavigation = false;
+      } else if (connector.state == MeshCoreConnectionState.connected &&
+          !_changedNavigation) {
+        _changedNavigation = true;
+        if (mounted) {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (context) => const ContactsScreen()),
+          );
+        }
+      }
+    };
+
+    connector.addListener(_connectionListener);
+  }
+
+  @override
+  void dispose() {
+    final connector = Provider.of<MeshCoreConnector>(context, listen: false);
+    connector.removeListener(_connectionListener);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: AdaptiveAppBarTitle(context.l10n.scanner_title),
+        centerTitle: true,
+        automaticallyImplyLeading: false,
+      ),
+      body: SafeArea(
+        top: false,
+        child: Center(
+          child: Consumer<MeshCoreConnector>(
+            builder: (context, connector, child) {
+              final isBusy =
+                  connector.state == MeshCoreConnectionState.scanning ||
+                      connector.state == MeshCoreConnectionState.connecting ||
+                      connector.state == MeshCoreConnectionState.connected ||
+                      connector.state ==
+                          MeshCoreConnectionState.disconnecting;
+
+              String? statusLabel;
+              if (connector.state == MeshCoreConnectionState.scanning) {
+                statusLabel = context.l10n.scanner_scanning;
+              } else if (connector.state == MeshCoreConnectionState.connecting ||
+                  connector.state == MeshCoreConnectionState.disconnecting) {
+                statusLabel = context.l10n.scanner_connecting;
+              }
+
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.bluetooth,
+                    size: 80,
+                    color: Colors.grey[400],
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: 260,
+                    child: FilledButton.icon(
+                      onPressed: isBusy
+                          ? null
+                          : () {
+                              unawaited(
+                                connector.startScan().catchError((e) {
+                                  if (!mounted) return;
+                                  final msg = e.toString().contains('Timed out')
+                                      ? 'Connection timed out. Please try again.'
+                                      : e.toString();
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        context.l10n.scanner_connectionFailed(msg),
+                                      ),
+                                      backgroundColor: Colors.red,
+                                    ),
+                                  );
+                                }),
+                              );
+                            },
+                      icon: isBusy && connector.state == MeshCoreConnectionState.connecting
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white,
+                              ),
+                            )
+                          : const Icon(Icons.bluetooth_searching),
+                      label: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: Text(
+                          context.l10n.common_connect,
+                          style: const TextStyle(fontSize: 18),
+                        ),
+                      ),
+                    ),
+                  ),
+                  if (statusLabel != null) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      statusLabel,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/patches/flutter_blue_plus_web/analysis_options.yaml
+++ b/patches/flutter_blue_plus_web/analysis_options.yaml
@@ -1,0 +1,28 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/tools/linter-rules.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/tools/analysis

--- a/patches/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
+++ b/patches/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
@@ -10,21 +10,31 @@ import 'src/html.dart';
 import 'src/web_bluetooth.dart';
 
 final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
-  late final _characteristicValueChangedEventListener = _handleCharacteristicValueChanged.toJS;
+  late final _characteristicValueChangedEventListener =
+      _handleCharacteristicValueChanged.toJS;
 
   final _devices = <DeviceIdentifier, BluetoothDevice>{};
 
   // for instanceIds
-  final _charCache = <DeviceIdentifier, Map<Guid, Map<Guid, List<BluetoothRemoteGATTCharacteristic>>>>{};
+  final _charCache = <DeviceIdentifier,
+      Map<Guid, Map<Guid, List<BluetoothRemoteGATTCharacteristic>>>>{};
 
-  final _onCharacteristicReceivedController = StreamController<BmCharacteristicData>.broadcast();
-  final _onCharacteristicWrittenController = StreamController<BmCharacteristicData>.broadcast();
-  final _onConnectionStateChangedController = StreamController<BmConnectionStateResponse>.broadcast();
-  final _onDescriptorReadController = StreamController<BmDescriptorData>.broadcast();
-  final _onDescriptorWrittenController = StreamController<BmDescriptorData>.broadcast();
-  final _onDevicesChangedController = StreamController<List<BluetoothDevice>>.broadcast();
-  final _onDiscoveredServicesController = StreamController<BmDiscoverServicesResult>.broadcast();
-  final _onScanResponseController = StreamController<BmScanResponse>.broadcast();
+  final _onCharacteristicReceivedController =
+      StreamController<BmCharacteristicData>.broadcast();
+  final _onCharacteristicWrittenController =
+      StreamController<BmCharacteristicData>.broadcast();
+  final _onConnectionStateChangedController =
+      StreamController<BmConnectionStateResponse>.broadcast();
+  final _onDescriptorReadController =
+      StreamController<BmDescriptorData>.broadcast();
+  final _onDescriptorWrittenController =
+      StreamController<BmDescriptorData>.broadcast();
+  final _onDevicesChangedController =
+      StreamController<List<BluetoothDevice>>.broadcast();
+  final _onDiscoveredServicesController =
+      StreamController<BmDiscoverServicesResult>.broadcast();
+  final _onScanResponseController =
+      StreamController<BmScanResponse>.broadcast();
 
   BluetoothRemoteGATTCharacteristic _findCharacteristicOrThrow({
     required DeviceIdentifier devId,
@@ -41,7 +51,8 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
     return list[instanceId];
   }
 
-  int _instanceId(DeviceIdentifier devId, Guid serviceUuid, BluetoothRemoteGATTCharacteristic target) {
+  int _instanceId(DeviceIdentifier devId, Guid serviceUuid,
+      BluetoothRemoteGATTCharacteristic target) {
     final list = _charCache[devId]?[serviceUuid]?[Guid(target.uuid)];
     if (list == null) return 0;
     final idx = list.indexWhere((c) => identical(c, target));
@@ -206,7 +217,8 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
           ..clear()
           ..addAll(<Guid, List<BluetoothRemoteGATTCharacteristic>>{});
         for (final c in chars) {
-          (charsByUuid[Guid(c.uuid)] ??= <BluetoothRemoteGATTCharacteristic>[]).add(c);
+          (charsByUuid[Guid(c.uuid)] ??= <BluetoothRemoteGATTCharacteristic>[])
+              .add(c);
         }
 
         for (final c in chars) {
@@ -245,7 +257,8 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
                 write: c.properties.write,
                 notify: c.properties.notify,
                 indicate: c.properties.indicate,
-                authenticatedSignedWrites: c.properties.authenticatedSignedWrites,
+                authenticatedSignedWrites:
+                    c.properties.authenticatedSignedWrites,
                 extendedProperties: false,
                 notifyEncryptionRequired: false,
                 indicateEncryptionRequired: false,
@@ -307,7 +320,8 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
   ) {
     return isSupported(BmIsSupportedRequest()).then(
       (supported) => BmBluetoothAdapterState(
-        adapterState: supported ? BmAdapterStateEnum.on : BmAdapterStateEnum.unknown,
+        adapterState:
+            supported ? BmAdapterStateEnum.on : BmAdapterStateEnum.unknown,
       ),
     );
   }
@@ -413,7 +427,9 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
       );
 
       // Then resolve descriptor by UUID on that characteristic
-      final descriptor = await characteristic.getDescriptor(request.descriptorUuid.str128.toJS).toDart;
+      final descriptor = await characteristic
+          .getDescriptor(request.descriptorUuid.str128.toJS)
+          .toDart;
 
       final value = (await descriptor.readValue().toDart).toDart;
 
@@ -559,17 +575,24 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
       if (filters.isNotEmpty) {
         options = RequestDeviceOptions(
           filters: filters.toJS,
-          optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,
+          optionalServices: request.webOptionalServices
+              .map((e) => e.str128.toJS)
+              .toList()
+              .toJS,
         );
       } else {
         // https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#acceptalldevices
         options = RequestDeviceOptions(
           acceptAllDevices: true,
-          optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,
+          optionalServices: request.webOptionalServices
+              .map((e) => e.str128.toJS)
+              .toList()
+              .toJS,
         );
       }
 
-      final device = await window.navigator.bluetooth.requestDevice(options).toDart;
+      final device =
+          await window.navigator.bluetooth.requestDevice(options).toDart;
 
       _devices[device.remoteId] = device;
       _onDevicesChangedController.add([..._devices.values]);
@@ -644,9 +667,13 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
       );
 
       if (request.writeType == BmWriteType.withResponse) {
-        await characteristic.writeValueWithResponse(Uint8List.fromList(request.value).toJS).toDart;
+        await characteristic
+            .writeValueWithResponse(Uint8List.fromList(request.value).toJS)
+            .toDart;
       } else {
-        await characteristic.writeValueWithoutResponse(Uint8List.fromList(request.value).toJS).toDart;
+        await characteristic
+            .writeValueWithoutResponse(Uint8List.fromList(request.value).toJS)
+            .toDart;
       }
 
       _onCharacteristicWrittenController.add(
@@ -715,9 +742,13 @@ final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
         instanceId: request.instanceId,
       );
 
-      final descriptor = await characteristic.getDescriptor(request.descriptorUuid.str128.toJS).toDart;
+      final descriptor = await characteristic
+          .getDescriptor(request.descriptorUuid.str128.toJS)
+          .toDart;
 
-      await descriptor.writeValue(Uint8List.fromList(request.value).toJS).toDart;
+      await descriptor
+          .writeValue(Uint8List.fromList(request.value).toJS)
+          .toDart;
 
       _onDescriptorWrittenController.add(
         BmDescriptorData(

--- a/patches/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
+++ b/patches/flutter_blue_plus_web/lib/flutter_blue_plus_web.dart
@@ -1,0 +1,786 @@
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:flutter_blue_plus_platform_interface/flutter_blue_plus_platform_interface.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:web/web.dart' show Event;
+
+import 'src/html.dart';
+import 'src/web_bluetooth.dart';
+
+final class FlutterBluePlusWeb extends FlutterBluePlusPlatform {
+  late final _characteristicValueChangedEventListener = _handleCharacteristicValueChanged.toJS;
+
+  final _devices = <DeviceIdentifier, BluetoothDevice>{};
+
+  // for instanceIds
+  final _charCache = <DeviceIdentifier, Map<Guid, Map<Guid, List<BluetoothRemoteGATTCharacteristic>>>>{};
+
+  final _onCharacteristicReceivedController = StreamController<BmCharacteristicData>.broadcast();
+  final _onCharacteristicWrittenController = StreamController<BmCharacteristicData>.broadcast();
+  final _onConnectionStateChangedController = StreamController<BmConnectionStateResponse>.broadcast();
+  final _onDescriptorReadController = StreamController<BmDescriptorData>.broadcast();
+  final _onDescriptorWrittenController = StreamController<BmDescriptorData>.broadcast();
+  final _onDevicesChangedController = StreamController<List<BluetoothDevice>>.broadcast();
+  final _onDiscoveredServicesController = StreamController<BmDiscoverServicesResult>.broadcast();
+  final _onScanResponseController = StreamController<BmScanResponse>.broadcast();
+
+  BluetoothRemoteGATTCharacteristic _findCharacteristicOrThrow({
+    required DeviceIdentifier devId,
+    required Guid serviceUuid,
+    required Guid charUuid,
+    required int instanceId,
+  }) {
+    final list = _charCache[devId]?[serviceUuid]?[charUuid];
+    if (list == null || instanceId < 0 || instanceId >= list.length) {
+      throw Exception(
+        'Characteristic not found in cache: service=$serviceUuid char=$charUuid instanceId=$instanceId',
+      );
+    }
+    return list[instanceId];
+  }
+
+  int _instanceId(DeviceIdentifier devId, Guid serviceUuid, BluetoothRemoteGATTCharacteristic target) {
+    final list = _charCache[devId]?[serviceUuid]?[Guid(target.uuid)];
+    if (list == null) return 0;
+    final idx = list.indexWhere((c) => identical(c, target));
+    return idx >= 0 ? idx : 0;
+  }
+
+  @override
+  Stream<BmCharacteristicData> get onCharacteristicReceived {
+    return _onCharacteristicReceivedController.stream;
+  }
+
+  @override
+  Stream<BmCharacteristicData> get onCharacteristicWritten {
+    return _onCharacteristicWrittenController.stream;
+  }
+
+  @override
+  Stream<BmConnectionStateResponse> get onConnectionStateChanged {
+    return _onConnectionStateChangedController.stream;
+  }
+
+  @override
+  Stream<BmDescriptorData> get onDescriptorRead {
+    return _onDescriptorReadController.stream;
+  }
+
+  @override
+  Stream<BmDescriptorData> get onDescriptorWritten {
+    return _onDescriptorWrittenController.stream;
+  }
+
+  @override
+  Stream<BmDiscoverServicesResult> get onDiscoveredServices {
+    return _onDiscoveredServicesController.stream;
+  }
+
+  @override
+  Stream<BmScanResponse> get onScanResponse {
+    return _onScanResponseController.stream;
+  }
+
+  static void registerWith(
+    Registrar registrar,
+  ) {
+    FlutterBluePlusPlatform.instance = FlutterBluePlusWeb();
+  }
+
+  @override
+  Future<bool> connect(
+    BmConnectRequest request,
+  ) async {
+    final device = _devices[request.remoteId];
+
+    if (device == null) {
+      throw Exception(
+        'The device "${request.remoteId}" could not be found.',
+      );
+    }
+
+    final gatt = device.gatt;
+
+    if (gatt == null) {
+      throw Exception(
+        'The gatt for the device "${request.remoteId}" is null.',
+      );
+    }
+
+    await gatt.connect().toDart;
+
+    _onConnectionStateChangedController.add(
+      BmConnectionStateResponse(
+        remoteId: device.remoteId,
+        connectionState: BmConnectionStateEnum.connected,
+        disconnectReasonCode: null,
+        disconnectReasonString: null,
+      ),
+    );
+
+    return true;
+  }
+
+  @override
+  Future<bool> disconnect(
+    BmDisconnectRequest request,
+  ) async {
+    final device = _devices[request.remoteId];
+
+    if (device == null) {
+      throw Exception(
+        'The device "${request.remoteId}" could not be found.',
+      );
+    }
+
+    final gatt = device.gatt;
+
+    if (gatt == null) {
+      throw Exception(
+        'The gatt for the device "${request.remoteId}" is null.',
+      );
+    }
+
+    gatt.disconnect();
+
+    // drop cache for this device to avoid stale entries
+    _charCache.remove(request.remoteId);
+
+    _onConnectionStateChangedController.add(
+      BmConnectionStateResponse(
+        remoteId: device.remoteId,
+        connectionState: BmConnectionStateEnum.disconnected,
+        disconnectReasonCode: null,
+        disconnectReasonString: null,
+      ),
+    );
+
+    return true;
+  }
+
+  @override
+  Future<bool> discoverServices(
+    BmDiscoverServicesRequest request,
+  ) async {
+    try {
+      final device = _devices[request.remoteId];
+
+      if (device == null) {
+        throw Exception(
+          'The device "${request.remoteId}" could not be found.',
+        );
+      }
+
+      final gatt = device.gatt;
+
+      if (gatt == null) {
+        throw Exception(
+          'The gatt for the device "${request.remoteId}" is null.',
+        );
+      }
+
+      final services = <BmBluetoothService>[];
+
+      // ensure dev map exists
+      final devMap = _charCache.putIfAbsent(device.remoteId, () {
+        return <Guid, Map<Guid, List<BluetoothRemoteGATTCharacteristic>>>{};
+      });
+
+      // Enumerate services and characteristics; build cache synchronously from discovery results
+      final primaryServices = (await gatt.getPrimaryServices().toDart).toDart;
+      for (final s in primaryServices) {
+        final characteristics = <BmBluetoothCharacteristic>[];
+
+        // reset/ensure service map
+        final charsByUuid = devMap.putIfAbsent(Guid(s.uuid), () {
+          return <Guid, List<BluetoothRemoteGATTCharacteristic>>{};
+        });
+
+        // pull all chars and cache them grouped by char.uuid (order matters and defines instanceId)
+        final chars = (await s.getCharacteristics().toDart).toDart;
+
+        // rebuild for this service
+        charsByUuid
+          ..clear()
+          ..addAll(<Guid, List<BluetoothRemoteGATTCharacteristic>>{});
+        for (final c in chars) {
+          (charsByUuid[Guid(c.uuid)] ??= <BluetoothRemoteGATTCharacteristic>[]).add(c);
+        }
+
+        for (final c in chars) {
+          final descriptors = <BmBluetoothDescriptor>[];
+
+          try {
+            final descs = (await c.getDescriptors().toDart).toDart;
+            for (final d in descs) {
+              descriptors.add(
+                BmBluetoothDescriptor(
+                  remoteId: device.remoteId,
+                  primaryServiceUuid: null,
+                  serviceUuid: Guid(s.uuid),
+                  characteristicUuid: Guid(c.uuid),
+                  instanceId: _instanceId(device.remoteId, Guid(s.uuid), c),
+                  descriptorUuid: Guid(d.uuid),
+                ),
+              );
+            }
+          } catch (e) {
+            // ignore errors when getting characteristics descriptors
+          }
+
+          characteristics.add(
+            BmBluetoothCharacteristic(
+              remoteId: device.remoteId,
+              primaryServiceUuid: null,
+              serviceUuid: Guid(s.uuid),
+              characteristicUuid: Guid(c.uuid),
+              instanceId: _instanceId(device.remoteId, Guid(s.uuid), c),
+              descriptors: descriptors,
+              properties: BmCharacteristicProperties(
+                broadcast: c.properties.broadcast,
+                read: c.properties.read,
+                writeWithoutResponse: c.properties.writeWithoutResponse,
+                write: c.properties.write,
+                notify: c.properties.notify,
+                indicate: c.properties.indicate,
+                authenticatedSignedWrites: c.properties.authenticatedSignedWrites,
+                extendedProperties: false,
+                notifyEncryptionRequired: false,
+                indicateEncryptionRequired: false,
+              ),
+            ),
+          );
+        }
+
+        services.add(
+          BmBluetoothService(
+            remoteId: device.remoteId,
+            primaryServiceUuid: null,
+            serviceUuid: Guid(s.uuid),
+            characteristics: characteristics,
+          ),
+        );
+      }
+
+      _onDiscoveredServicesController.add(
+        BmDiscoverServicesResult(
+          remoteId: device.remoteId,
+          services: services,
+          success: true,
+          errorCode: 0,
+          errorString: '',
+        ),
+      );
+
+      return true;
+    } catch (e) {
+      _onDiscoveredServicesController.add(
+        BmDiscoverServicesResult(
+          remoteId: request.remoteId,
+          services: [],
+          success: false,
+          errorCode: 0,
+          errorString: e.toString(),
+        ),
+      );
+
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> isSupported(
+    BmIsSupportedRequest request,
+  ) async {
+    try {
+      return (await window.navigator.bluetooth.getAvailability().toDart).toDart;
+    } catch (e) {
+      return false; // https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API#browser_compatibility
+    }
+  }
+
+  @override
+  Future<BmBluetoothAdapterState> getAdapterState(
+    BmBluetoothAdapterStateRequest request,
+  ) {
+    return isSupported(BmIsSupportedRequest()).then(
+      (supported) => BmBluetoothAdapterState(
+        adapterState: supported ? BmAdapterStateEnum.on : BmAdapterStateEnum.unknown,
+      ),
+    );
+  }
+
+  @override
+  Future<bool> readCharacteristic(
+    BmReadCharacteristicRequest request,
+  ) async {
+    try {
+      final device = _devices[request.remoteId];
+
+      if (device == null) {
+        throw Exception(
+          'The device "${request.remoteId}" could not be found.',
+        );
+      }
+
+      final gatt = device.gatt;
+
+      if (gatt == null) {
+        throw Exception(
+          'The gatt for the device "${request.remoteId}" is null.',
+        );
+      }
+
+      final serviceUuid = request.serviceUuid.str128;
+      final charUuid = request.characteristicUuid.str128;
+
+      // Resolve characteristic from cache using instanceId
+      final characteristic = _findCharacteristicOrThrow(
+        devId: device.remoteId,
+        serviceUuid: Guid(serviceUuid),
+        charUuid: Guid(charUuid),
+        instanceId: request.instanceId,
+      );
+
+      final value = (await characteristic.readValue().toDart).toDart;
+
+      _onCharacteristicReceivedController.add(
+        BmCharacteristicData(
+          remoteId: device.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          value: value.buffer.asUint8List(),
+          success: true,
+          errorCode: 0,
+          errorString: '',
+        ),
+      );
+
+      return true;
+    } catch (e) {
+      _onCharacteristicReceivedController.add(
+        BmCharacteristicData(
+          remoteId: request.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          value: [],
+          success: false,
+          errorCode: 0,
+          errorString: e.toString(),
+        ),
+      );
+
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> readDescriptor(
+    BmReadDescriptorRequest request,
+  ) async {
+    try {
+      final device = _devices[request.remoteId];
+
+      if (device == null) {
+        throw Exception(
+          'The device "${request.remoteId}" could not be found.',
+        );
+      }
+
+      final gatt = device.gatt;
+
+      if (gatt == null) {
+        throw Exception(
+          'The gatt for the device "${request.remoteId}" is null.',
+        );
+      }
+
+      final serviceUuid = request.serviceUuid.str128;
+      final charUuid = request.characteristicUuid.str128;
+
+      // Resolve characteristic by instanceId from cache
+      final characteristic = _findCharacteristicOrThrow(
+        devId: device.remoteId,
+        serviceUuid: Guid(serviceUuid),
+        charUuid: Guid(charUuid),
+        instanceId: request.instanceId,
+      );
+
+      // Then resolve descriptor by UUID on that characteristic
+      final descriptor = await characteristic.getDescriptor(request.descriptorUuid.str128.toJS).toDart;
+
+      final value = (await descriptor.readValue().toDart).toDart;
+
+      _onDescriptorReadController.add(
+        BmDescriptorData(
+          remoteId: device.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          descriptorUuid: Guid.fromString(descriptor.uuid),
+          value: value.buffer.asUint8List(),
+          success: true,
+          errorCode: 0,
+          errorString: '',
+        ),
+      );
+
+      return true;
+    } catch (e) {
+      _onDescriptorReadController.add(
+        BmDescriptorData(
+          remoteId: request.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          descriptorUuid: request.descriptorUuid,
+          value: [],
+          success: false,
+          errorCode: 0,
+          errorString: e.toString(),
+        ),
+      );
+
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> setNotifyValue(
+    BmSetNotifyValueRequest request,
+  ) async {
+    final device = _devices[request.remoteId];
+
+    if (device == null) {
+      throw Exception(
+        'The device "${request.remoteId}" could not be found.',
+      );
+    }
+
+    final gatt = device.gatt;
+
+    if (gatt == null) {
+      throw Exception(
+        'The gatt for the device "${request.remoteId}" is null.',
+      );
+    }
+
+    final serviceUuid = request.serviceUuid.str128;
+    final charUuid = request.characteristicUuid.str128;
+
+    // Resolve from cache using instanceId
+    final characteristic = _findCharacteristicOrThrow(
+      devId: device.remoteId,
+      serviceUuid: Guid(serviceUuid),
+      charUuid: Guid(charUuid),
+      instanceId: request.instanceId,
+    );
+
+    if (request.enable) {
+      characteristic.addEventListener(
+        'characteristicvaluechanged',
+        _characteristicValueChangedEventListener,
+      );
+
+      await characteristic.startNotifications().toDart;
+    } else {
+      await characteristic.stopNotifications().toDart;
+
+      characteristic.removeEventListener(
+        'characteristicvaluechanged',
+        _characteristicValueChangedEventListener,
+      );
+    }
+
+    // Return false so the Dart layer does not wait for a CCCD descriptor write
+    // event (Web Bluetooth does not expose that), which would cause a 15s timeout.
+    return false;
+  }
+
+  @override
+  Future<bool> startScan(
+    BmScanSettings request,
+  ) async {
+    try {
+      final filters = <BluetoothLEScanFilterInit>[];
+
+      for (final service in request.withServices) {
+        filters.add(
+          BluetoothLEScanFilterInit(
+            services: [
+              service.str128.toJS,
+            ].toJS,
+          ),
+        );
+      }
+
+      for (final name in request.withNames) {
+        filters.add(
+          BluetoothLEScanFilterInit(
+            name: name,
+          ),
+        );
+      }
+
+      for (final manufacturerData in request.withMsd) {
+        filters.add(
+          BluetoothLEScanFilterInit(
+            manufacturerData: [
+              BluetoothManufacturerDataFilterInit(
+                companyIdentifier: manufacturerData.manufacturerId,
+              ),
+            ].toJS,
+          ),
+        );
+      }
+
+      for (final serviceData in request.withServiceData) {
+        filters.add(
+          BluetoothLEScanFilterInit(
+            serviceData: [
+              BluetoothServiceDataFilterInit(
+                service: serviceData.service.str128.toJS,
+              ),
+            ].toJS,
+          ),
+        );
+      }
+
+      final RequestDeviceOptions options;
+
+      if (filters.isNotEmpty) {
+        options = RequestDeviceOptions(
+          filters: filters.toJS,
+          optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,
+        );
+      } else {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#acceptalldevices
+        options = RequestDeviceOptions(
+          acceptAllDevices: true,
+          optionalServices: request.webOptionalServices.map((e) => e.str128.toJS).toList().toJS,
+        );
+      }
+
+      final device = await window.navigator.bluetooth.requestDevice(options).toDart;
+
+      _devices[device.remoteId] = device;
+      _onDevicesChangedController.add([..._devices.values]);
+
+      _onScanResponseController.add(
+        BmScanResponse(
+          advertisements: [
+            BmScanAdvertisement(
+              remoteId: device.remoteId,
+              platformName: device.name,
+              advName: null,
+              connectable: true,
+              txPowerLevel: null,
+              appearance: null,
+              manufacturerData: {},
+              serviceData: {},
+              serviceUuids: [],
+              rssi: 0,
+            ),
+          ],
+          success: true,
+          errorCode: 0,
+          errorString: '',
+        ),
+      );
+
+      return true;
+    } catch (e) {
+      _onScanResponseController.add(
+        BmScanResponse(
+          advertisements: [],
+          success: false,
+          errorCode: 0,
+          errorString: e.toString(),
+        ),
+      );
+
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> writeCharacteristic(
+    BmWriteCharacteristicRequest request,
+  ) async {
+    try {
+      final device = _devices[request.remoteId];
+
+      if (device == null) {
+        throw Exception(
+          'The device "${request.remoteId}" could not be found.',
+        );
+      }
+
+      final gatt = device.gatt;
+
+      if (gatt == null) {
+        throw Exception(
+          'The gatt for the device "${request.remoteId}" is null.',
+        );
+      }
+
+      final serviceUuid = request.serviceUuid.str128;
+      final charUuid = request.characteristicUuid.str128;
+
+      // Resolve characteristic from cache using instanceId
+      final characteristic = _findCharacteristicOrThrow(
+        devId: device.remoteId,
+        serviceUuid: Guid(serviceUuid),
+        charUuid: Guid(charUuid),
+        instanceId: request.instanceId,
+      );
+
+      if (request.writeType == BmWriteType.withResponse) {
+        await characteristic.writeValueWithResponse(Uint8List.fromList(request.value).toJS).toDart;
+      } else {
+        await characteristic.writeValueWithoutResponse(Uint8List.fromList(request.value).toJS).toDart;
+      }
+
+      _onCharacteristicWrittenController.add(
+        BmCharacteristicData(
+          remoteId: device.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          value: request.value,
+          success: true,
+          errorCode: 0,
+          errorString: '',
+        ),
+      );
+
+      return true;
+    } catch (e) {
+      _onCharacteristicWrittenController.add(
+        BmCharacteristicData(
+          remoteId: request.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          value: request.value,
+          success: false,
+          errorCode: 0,
+          errorString: e.toString(),
+        ),
+      );
+
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> writeDescriptor(
+    BmWriteDescriptorRequest request,
+  ) async {
+    try {
+      final device = _devices[request.remoteId];
+
+      if (device == null) {
+        throw Exception(
+          'The device "${request.remoteId}" could not be found.',
+        );
+      }
+
+      final gatt = device.gatt;
+
+      if (gatt == null) {
+        throw Exception(
+          'The gatt for the device "${request.remoteId}" is null.',
+        );
+      }
+
+      final serviceUuid = request.serviceUuid.str128;
+      final charUuid = request.characteristicUuid.str128;
+
+      // Resolve characteristic by instanceId from cache
+      final characteristic = _findCharacteristicOrThrow(
+        devId: device.remoteId,
+        serviceUuid: Guid(serviceUuid),
+        charUuid: Guid(charUuid),
+        instanceId: request.instanceId,
+      );
+
+      final descriptor = await characteristic.getDescriptor(request.descriptorUuid.str128.toJS).toDart;
+
+      await descriptor.writeValue(Uint8List.fromList(request.value).toJS).toDart;
+
+      _onDescriptorWrittenController.add(
+        BmDescriptorData(
+          remoteId: device.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          descriptorUuid: Guid.fromString(descriptor.uuid),
+          value: request.value,
+          success: true,
+          errorCode: 0,
+          errorString: '',
+        ),
+      );
+
+      return true;
+    } catch (e) {
+      _onDescriptorWrittenController.add(
+        BmDescriptorData(
+          remoteId: request.remoteId,
+          primaryServiceUuid: null,
+          serviceUuid: request.serviceUuid,
+          characteristicUuid: request.characteristicUuid,
+          instanceId: request.instanceId,
+          descriptorUuid: request.descriptorUuid,
+          value: request.value,
+          success: false,
+          errorCode: 0,
+          errorString: e.toString(),
+        ),
+      );
+
+      return false;
+    }
+  }
+
+  void _handleCharacteristicValueChanged(
+    Event event,
+  ) {
+    final characteristic = event.target as BluetoothRemoteGATTCharacteristic;
+
+    final devId = characteristic.service.device.remoteId;
+    final svcUuid = characteristic.service.uuid;
+
+    _onCharacteristicReceivedController.add(
+      BmCharacteristicData(
+        remoteId: devId,
+        primaryServiceUuid: null,
+        serviceUuid: Guid.fromString(svcUuid),
+        characteristicUuid: Guid.fromString(characteristic.uuid),
+        instanceId: _instanceId(devId, Guid(svcUuid), characteristic),
+        value: characteristic.value?.toDart.buffer.asUint8List() ?? [],
+        success: true,
+        errorCode: 0,
+        errorString: '',
+      ),
+    );
+  }
+}
+
+extension on BluetoothDevice {
+  DeviceIdentifier get remoteId {
+    return DeviceIdentifier(id);
+  }
+}

--- a/patches/flutter_blue_plus_web/lib/src/html.dart
+++ b/patches/flutter_blue_plus_web/lib/src/html.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// API docs from [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web).
+// Attributions and copyright licensing by Mozilla Contributors is licensed
+// under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/.
+
+// Generated from Web IDL definitions.
+
+// ignore_for_file: unintended_html_in_doc_comment
+
+@JS()
+library;
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart' show EventTarget;
+
+import 'web_bluetooth.dart';
+
+@JS()
+external Window get window;
+
+/// The **`Window`** interface represents a window containing a  document; the
+/// `document` property points to the
+/// [DOM document](https://developer.mozilla.org/en-US/docs/Web/API/Document)
+/// loaded in that window.
+///
+/// A window for a given document can be obtained using the
+/// [document.defaultView] property.
+///
+/// A global variable, `window`, representing the window in which the script is
+/// running, is exposed to JavaScript code.
+///
+/// The `Window` interface is home to a variety of functions, namespaces,
+/// objects, and constructors which are not necessarily directly associated with
+/// the concept of a user interface window. However, the `Window` interface is a
+/// suitable place to include these items that need to be globally available.
+/// Many of these are documented in the
+/// [JavaScript Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
+/// and the
+/// [DOM Reference](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model).
+///
+/// In a tabbed browser, each tab is represented by its own `Window` object; the
+/// global `window` seen by JavaScript code running within a given tab always
+/// represents the tab in which the code is running. That said, even in a tabbed
+/// browser, some properties and methods still apply to the overall window that
+/// contains the tab, such as [Window.resizeTo] and [Window.innerHeight].
+/// Generally, anything that can't reasonably pertain to a tab pertains to the
+/// window instead.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Window).
+extension type Window._(JSObject _) implements EventTarget, JSObject {
+  /// The **`Window.navigator`** read-only property returns a
+  /// reference to the [Navigator] object, which has methods and properties
+  /// about the application running the script.
+  external Navigator get navigator;
+}
+
+/// The **`Navigator`** interface represents the state and the identity of the
+/// user agent. It allows scripts to query it and to register themselves to
+/// carry on some activities.
+///
+/// A `Navigator` object can be retrieved using the read-only [window.navigator]
+/// property.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Navigator).
+extension type Navigator._(JSObject _) implements JSObject {
+  /// The **`bluetooth`** read-only property of the [Navigator] interface returns
+  /// a [Bluetooth] object for the current document, providing access to
+  /// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+  /// functionality.
+  external Bluetooth get bluetooth;
+}

--- a/patches/flutter_blue_plus_web/lib/src/web_bluetooth.dart
+++ b/patches/flutter_blue_plus_web/lib/src/web_bluetooth.dart
@@ -1,0 +1,634 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// API docs from [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web).
+// Attributions and copyright licensing by Mozilla Contributors is licensed
+// under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/.
+
+// Generated from Web IDL definitions.
+
+// ignore_for_file: unintended_html_in_doc_comment
+
+@JS()
+library;
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart' show AbortSignal, BufferSource, Event, EventHandler, EventInit, EventTarget, PermissionStatus;
+
+typedef UUID = String;
+typedef BluetoothServiceUUID = JSAny;
+typedef BluetoothCharacteristicUUID = JSAny;
+typedef BluetoothDescriptorUUID = JSAny;
+extension type BluetoothDataFilterInit._(JSObject _) implements JSObject {
+  external factory BluetoothDataFilterInit({
+    BufferSource dataPrefix,
+    BufferSource mask,
+  });
+
+  external BufferSource get dataPrefix;
+  external set dataPrefix(BufferSource value);
+  external BufferSource get mask;
+  external set mask(BufferSource value);
+}
+extension type BluetoothManufacturerDataFilterInit._(JSObject _)
+    implements BluetoothDataFilterInit, JSObject {
+  external factory BluetoothManufacturerDataFilterInit({
+    BufferSource dataPrefix,
+    BufferSource mask,
+    required int companyIdentifier,
+  });
+
+  external int get companyIdentifier;
+  external set companyIdentifier(int value);
+}
+extension type BluetoothServiceDataFilterInit._(JSObject _)
+    implements BluetoothDataFilterInit, JSObject {
+  external factory BluetoothServiceDataFilterInit({
+    BufferSource dataPrefix,
+    BufferSource mask,
+    required BluetoothServiceUUID service,
+  });
+
+  external BluetoothServiceUUID get service;
+  external set service(BluetoothServiceUUID value);
+}
+extension type BluetoothLEScanFilterInit._(JSObject _) implements JSObject {
+  external factory BluetoothLEScanFilterInit({
+    JSArray<BluetoothServiceUUID> services,
+    String name,
+    String namePrefix,
+    JSArray<BluetoothManufacturerDataFilterInit> manufacturerData,
+    JSArray<BluetoothServiceDataFilterInit> serviceData,
+  });
+
+  external JSArray<BluetoothServiceUUID> get services;
+  external set services(JSArray<BluetoothServiceUUID> value);
+  external String get name;
+  external set name(String value);
+  external String get namePrefix;
+  external set namePrefix(String value);
+  external JSArray<BluetoothManufacturerDataFilterInit> get manufacturerData;
+  external set manufacturerData(
+      JSArray<BluetoothManufacturerDataFilterInit> value);
+  external JSArray<BluetoothServiceDataFilterInit> get serviceData;
+  external set serviceData(JSArray<BluetoothServiceDataFilterInit> value);
+}
+extension type RequestDeviceOptions._(JSObject _) implements JSObject {
+  external factory RequestDeviceOptions({
+    JSArray<BluetoothLEScanFilterInit> filters,
+    JSArray<BluetoothLEScanFilterInit> exclusionFilters,
+    JSArray<BluetoothServiceUUID> optionalServices,
+    JSArray<JSNumber> optionalManufacturerData,
+    bool acceptAllDevices,
+  });
+
+  external JSArray<BluetoothLEScanFilterInit> get filters;
+  external set filters(JSArray<BluetoothLEScanFilterInit> value);
+  external JSArray<BluetoothLEScanFilterInit> get exclusionFilters;
+  external set exclusionFilters(JSArray<BluetoothLEScanFilterInit> value);
+  external JSArray<BluetoothServiceUUID> get optionalServices;
+  external set optionalServices(JSArray<BluetoothServiceUUID> value);
+  external JSArray<JSNumber> get optionalManufacturerData;
+  external set optionalManufacturerData(JSArray<JSNumber> value);
+  external bool get acceptAllDevices;
+  external set acceptAllDevices(bool value);
+}
+
+/// The **`Bluetooth`** interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// provides methods to query Bluetooth availability and request access to
+/// devices.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth).
+extension type Bluetooth._(JSObject _) implements EventTarget, JSObject {
+  /// The **`getAvailability()`** method of the [Bluetooth] interface
+  /// _nominally_ returns `true` if the user agent can support Bluetooth
+  /// (because the device has a Bluetooth adapter), and `false` otherwise.
+  ///
+  /// The word "nominally" is used because if permission to use the Web
+  /// Bluetooth API is disallowed by the [`Permissions-Policy:
+  /// bluetooth`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/bluetooth)
+  /// permission, the method will always return `false`.
+  /// In addition, a user can configure their browser to return `false` from a
+  /// `getAvailability()` call even if the browser does have an operational
+  /// Bluetooth adapter, and vice versa. This setting value ignored if access is
+  /// blocked by the permission.
+  ///
+  /// Even if `getAvailability()` returns `true` and the device actually has a
+  /// Bluetooth adaptor, this does not necessarily mean that calling
+  /// [Bluetooth.requestDevice] will resolve with a [BluetoothDevice].
+  /// The Bluetooth adapter may not be powered, and a user might deny permission
+  /// to use the API when prompted.
+  external JSPromise<JSBoolean> getAvailability();
+
+  /// The **`getDevices()`** method of the [Bluetooth] interface returns an
+  /// array containing the Bluetooth devices that this origin is allowed to
+  /// access — including those that are out of range and powered off.
+  external JSPromise<JSArray<BluetoothDevice>> getDevices();
+
+  /// The **`Bluetooth.requestDevice()`** method of the [Bluetooth] interface
+  /// returns a `Promise` that fulfills with a [BluetoothDevice] object matching
+  /// the specified options.
+  /// If there is no chooser UI, this method returns the first device matching
+  /// the criteria.
+  external JSPromise<BluetoothDevice> requestDevice(
+      [RequestDeviceOptions options]);
+  external EventHandler get onavailabilitychanged;
+  external set onavailabilitychanged(EventHandler value);
+  external BluetoothDevice? get referringDevice;
+  external EventHandler get ongattserverdisconnected;
+  external set ongattserverdisconnected(EventHandler value);
+  external EventHandler get oncharacteristicvaluechanged;
+  external set oncharacteristicvaluechanged(EventHandler value);
+  external EventHandler get onserviceadded;
+  external set onserviceadded(EventHandler value);
+  external EventHandler get onservicechanged;
+  external set onservicechanged(EventHandler value);
+  external EventHandler get onserviceremoved;
+  external set onserviceremoved(EventHandler value);
+}
+extension type AllowedBluetoothDevice._(JSObject _) implements JSObject {
+  external factory AllowedBluetoothDevice({
+    required String deviceId,
+    required bool mayUseGATT,
+    required JSAny allowedServices,
+    required JSArray<JSNumber> allowedManufacturerData,
+  });
+
+  external String get deviceId;
+  external set deviceId(String value);
+  external bool get mayUseGATT;
+  external set mayUseGATT(bool value);
+  external JSAny get allowedServices;
+  external set allowedServices(JSAny value);
+  external JSArray<JSNumber> get allowedManufacturerData;
+  external set allowedManufacturerData(JSArray<JSNumber> value);
+}
+extension type BluetoothPermissionStorage._(JSObject _) implements JSObject {
+  external factory BluetoothPermissionStorage(
+      {required JSArray<AllowedBluetoothDevice> allowedDevices});
+
+  external JSArray<AllowedBluetoothDevice> get allowedDevices;
+  external set allowedDevices(JSArray<AllowedBluetoothDevice> value);
+}
+extension type BluetoothPermissionResult._(JSObject _)
+    implements PermissionStatus, JSObject {
+  external JSArray<BluetoothDevice> get devices;
+  external set devices(JSArray<BluetoothDevice> value);
+}
+extension type ValueEvent._(JSObject _) implements Event, JSObject {
+  external factory ValueEvent(
+    String type, [
+    ValueEventInit initDict,
+  ]);
+
+  external JSAny? get value;
+}
+extension type ValueEventInit._(JSObject _) implements EventInit, JSObject {
+  external factory ValueEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    JSAny? value,
+  });
+
+  external JSAny? get value;
+  external set value(JSAny? value);
+}
+
+/// The BluetoothDevice interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// represents a Bluetooth device inside a particular script execution
+/// environment.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice).
+extension type BluetoothDevice._(JSObject _) implements EventTarget, JSObject {
+  external JSPromise<JSAny?> forget();
+  external JSPromise<JSAny?> watchAdvertisements(
+      [WatchAdvertisementsOptions options]);
+
+  /// The **`BluetoothDevice.id`** read-only property returns a
+  /// string that uniquely identifies a device.
+  external String get id;
+
+  /// The **`BluetoothDevice.name`** read-only property returns a
+  /// string that provides a human-readable name for the device.
+  external String? get name;
+
+  /// The
+  /// **`BluetoothDevice.gatt`** read-only property returns
+  /// a reference to the device's [BluetoothRemoteGATTServer].
+  external BluetoothRemoteGATTServer? get gatt;
+  external bool get watchingAdvertisements;
+  external EventHandler get onadvertisementreceived;
+  external set onadvertisementreceived(EventHandler value);
+  external EventHandler get ongattserverdisconnected;
+  external set ongattserverdisconnected(EventHandler value);
+  external EventHandler get oncharacteristicvaluechanged;
+  external set oncharacteristicvaluechanged(EventHandler value);
+  external EventHandler get onserviceadded;
+  external set onserviceadded(EventHandler value);
+  external EventHandler get onservicechanged;
+  external set onservicechanged(EventHandler value);
+  external EventHandler get onserviceremoved;
+  external set onserviceremoved(EventHandler value);
+}
+extension type WatchAdvertisementsOptions._(JSObject _) implements JSObject {
+  external factory WatchAdvertisementsOptions({AbortSignal signal});
+
+  external AbortSignal get signal;
+  external set signal(AbortSignal value);
+}
+extension type BluetoothManufacturerDataMap._(JSObject _) implements JSObject {}
+extension type BluetoothServiceDataMap._(JSObject _) implements JSObject {}
+extension type BluetoothAdvertisingEvent._(JSObject _)
+    implements Event, JSObject {
+  external factory BluetoothAdvertisingEvent(
+    String type,
+    BluetoothAdvertisingEventInit init,
+  );
+
+  external BluetoothDevice get device;
+  external JSArray<JSString> get uuids;
+  external String? get name;
+  external int? get appearance;
+  external int? get txPower;
+  external int? get rssi;
+  external BluetoothManufacturerDataMap get manufacturerData;
+  external BluetoothServiceDataMap get serviceData;
+}
+extension type BluetoothAdvertisingEventInit._(JSObject _)
+    implements EventInit, JSObject {
+  external factory BluetoothAdvertisingEventInit({
+    bool bubbles,
+    bool cancelable,
+    bool composed,
+    required BluetoothDevice device,
+    JSArray<JSAny> uuids,
+    String name,
+    int appearance,
+    int txPower,
+    int rssi,
+    BluetoothManufacturerDataMap manufacturerData,
+    BluetoothServiceDataMap serviceData,
+  });
+
+  external BluetoothDevice get device;
+  external set device(BluetoothDevice value);
+  external JSArray<JSAny> get uuids;
+  external set uuids(JSArray<JSAny> value);
+  external String get name;
+  external set name(String value);
+  external int get appearance;
+  external set appearance(int value);
+  external int get txPower;
+  external set txPower(int value);
+  external int get rssi;
+  external set rssi(int value);
+  external BluetoothManufacturerDataMap get manufacturerData;
+  external set manufacturerData(BluetoothManufacturerDataMap value);
+  external BluetoothServiceDataMap get serviceData;
+  external set serviceData(BluetoothServiceDataMap value);
+}
+
+/// The **`BluetoothRemoteGATTServer`** interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// represents a GATT
+/// Server on a remote device.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTServer).
+extension type BluetoothRemoteGATTServer._(JSObject _) implements JSObject {
+  /// The
+  /// **`BluetoothRemoteGATTServer.connect()`** method causes the
+  /// script execution environment to connect to `this.device`.
+  external JSPromise<BluetoothRemoteGATTServer> connect();
+
+  /// The **`BluetoothRemoteGATTServer.disconnect()`** method causes
+  /// the script execution environment to disconnect from `this.device`.
+  external void disconnect();
+
+  /// The **`BluetoothRemoteGATTServer.getPrimaryService()`** method
+  /// returns a promise to the primary [BluetoothRemoteGATTService] offered by
+  /// the
+  /// Bluetooth device for a specified bluetooth service UUID.
+  external JSPromise<BluetoothRemoteGATTService> getPrimaryService(
+      BluetoothServiceUUID service);
+
+  /// The **BluetoothRemoteGATTServer.getPrimaryServices()** method returns a
+  /// promise to a list of primary [BluetoothRemoteGATTService] objects offered
+  /// by the
+  /// Bluetooth device for a specified `BluetoothServiceUUID`.
+  external JSPromise<JSArray<BluetoothRemoteGATTService>> getPrimaryServices(
+      [BluetoothServiceUUID service]);
+
+  /// The **`BluetoothRemoteGATTServer.device`** read-only property
+  /// returns a reference to the [BluetoothDevice] running the server.
+  external BluetoothDevice get device;
+
+  /// The **`BluetoothRemoteGATTServer.connected`** read-only
+  /// property returns a boolean value that returns true while this script
+  /// execution
+  /// environment is connected to `this.device`. It can be false while the user
+  /// agent is physically connected.
+  external bool get connected;
+}
+
+/// The `BluetoothRemoteGATTService` interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// represents a
+/// service provided by a GATT server, including a device, a list of referenced
+/// services,
+/// and a list of the characteristics of this service.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTService).
+extension type BluetoothRemoteGATTService._(JSObject _)
+    implements EventTarget, JSObject {
+  /// The **`BluetoothGATTService.getCharacteristic()`** method
+  /// returns a `Promise` to an instance of
+  /// [BluetoothRemoteGATTCharacteristic] for a given universally unique
+  /// identifier
+  /// (UUID).
+  external JSPromise<BluetoothRemoteGATTCharacteristic> getCharacteristic(
+      BluetoothCharacteristicUUID characteristic);
+
+  /// The **`BluetoothGATTService.getCharacteristics()`** method
+  /// returns a `Promise` to a list of [BluetoothRemoteGATTCharacteristic]
+  /// instances for a given universally unique identifier (UUID).
+  external JSPromise<JSArray<BluetoothRemoteGATTCharacteristic>>
+      getCharacteristics([BluetoothCharacteristicUUID characteristic]);
+  external JSPromise<BluetoothRemoteGATTService> getIncludedService(
+      BluetoothServiceUUID service);
+  external JSPromise<JSArray<BluetoothRemoteGATTService>> getIncludedServices(
+      [BluetoothServiceUUID service]);
+
+  /// The **`BluetoothGATTService.device`** read-only property
+  /// returns information about a Bluetooth device through an instance of
+  /// [BluetoothDevice].
+  external BluetoothDevice get device;
+
+  /// The **`BluetoothGATTService.uuid`** read-only property
+  /// returns a string representing the UUID of this service.
+  external UUID get uuid;
+
+  /// The **`BluetoothGATTService.isPrimary`** read-only property
+  /// returns a boolean value that indicates whether this is a primary service.
+  /// If it
+  /// is not a primary service, it is a secondary service.
+  external bool get isPrimary;
+  external EventHandler get oncharacteristicvaluechanged;
+  external set oncharacteristicvaluechanged(EventHandler value);
+  external EventHandler get onserviceadded;
+  external set onserviceadded(EventHandler value);
+  external EventHandler get onservicechanged;
+  external set onservicechanged(EventHandler value);
+  external EventHandler get onserviceremoved;
+  external set onserviceremoved(EventHandler value);
+}
+
+/// The `BluetoothRemoteGattCharacteristic` interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// represents a GATT Characteristic, which is a basic data element that
+/// provides further information about a peripheral's service.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic).
+extension type BluetoothRemoteGATTCharacteristic._(JSObject _)
+    implements EventTarget, JSObject {
+  /// The **`BluetoothRemoteGATTCharacteristic.getDescriptor()`** method
+  /// returns a `Promise` that resolves to the
+  /// first [BluetoothRemoteGATTDescriptor] for a given descriptor UUID.
+  external JSPromise<BluetoothRemoteGATTDescriptor> getDescriptor(
+      BluetoothDescriptorUUID descriptor);
+
+  /// The **`BluetoothRemoteGATTCharacteristic.getDescriptors()`** method
+  /// returns a `Promise` that resolves to an `Array` of all
+  /// [BluetoothRemoteGATTDescriptor] objects for a given descriptor UUID.
+  external JSPromise<JSArray<BluetoothRemoteGATTDescriptor>> getDescriptors(
+      [BluetoothDescriptorUUID descriptor]);
+
+  /// The **`BluetoothRemoteGATTCharacteristic.readValue()`** method
+  /// returns a `Promise` that resolves to a `DataView` holding a
+  /// duplicate of the `value` property if it is available and supported.
+  /// Otherwise
+  /// it throws an error.
+  external JSPromise<JSDataView> readValue();
+
+  /// Use [BluetoothRemoteGATTCharacteristic.writeValueWithResponse] and
+  /// [BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse] instead.
+  ///
+  /// The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a
+  /// [BluetoothRemoteGATTCharacteristic] object's `value` property to the bytes
+  /// contained in a given `ArrayBuffer`, calls
+  /// [`WriteCharacteristicValue`(_this_=`this`, _value=value_,
+  /// _response_=`"optional"`)](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue),
+  /// and returns the resulting `Promise`.
+  external JSPromise<JSAny?> writeValue(BufferSource value);
+
+  /// The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`**
+  /// method sets a [BluetoothRemoteGATTCharacteristic] object's `value`
+  /// property to the bytes contained in a given `ArrayBuffer`, calls
+  /// [`WriteCharacteristicValue`(_this_=`this`, _value=value_,
+  /// _response_=`"required"`)](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue),
+  /// and returns the resulting `Promise`.
+  external JSPromise<JSAny?> writeValueWithResponse(BufferSource value);
+
+  /// The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`**
+  /// method sets a [BluetoothRemoteGATTCharacteristic] object's `value`
+  /// property to the bytes contained in a given `ArrayBuffer`, calls
+  /// [`WriteCharacteristicValue`(_this_=`this`, _value=value_,
+  /// _response_=`"never"`)](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue),
+  /// and returns the resulting `Promise`.
+  external JSPromise<JSAny?> writeValueWithoutResponse(BufferSource value);
+
+  /// The **`BluetoothRemoteGATTCharacteristic.startNotifications()`** method
+  /// returns a `Promise` to the BluetoothRemoteGATTCharacteristic instance when
+  /// there is an active notification on it.
+  external JSPromise<BluetoothRemoteGATTCharacteristic> startNotifications();
+
+  /// The **`BluetoothRemoteGATTCharacteristic.stopNotifications()`** method
+  /// returns a `Promise` to the BluetoothRemoteGATTCharacteristic instance when
+  /// there is no longer an active notification on it.
+  external JSPromise<BluetoothRemoteGATTCharacteristic> stopNotifications();
+
+  /// The **`BluetoothRemoteGATTCharacteristic.service`** read-only
+  /// property returns the [BluetoothRemoteGATTService] this characteristic
+  /// belongs to.
+  external BluetoothRemoteGATTService get service;
+
+  /// The **`BluetoothRemoteGATTCharacteristic.uuid`** read-only
+  /// property returns a string containing the UUID of the characteristic, for
+  /// example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate
+  /// Measurement characteristic.
+  external UUID get uuid;
+
+  /// The **`BluetoothRemoteGATTCharacteristic.properties`**
+  /// read-only property returns a [BluetoothCharacteristicProperties] instance
+  /// containing the properties of this characteristic.
+  external BluetoothCharacteristicProperties get properties;
+
+  /// The **`BluetoothRemoteGATTCharacteristic.value`** read-only
+  /// property returns currently cached characteristic value. This value gets
+  /// updated when the
+  /// value of the characteristic is read or updated via a notification or
+  /// indication.
+  external JSDataView? get value;
+  external EventHandler get oncharacteristicvaluechanged;
+  external set oncharacteristicvaluechanged(EventHandler value);
+}
+
+/// The **`BluetoothCharacteristicProperties`** interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// provides the operations that are valid on the given
+/// [BluetoothRemoteGATTCharacteristic].
+///
+/// This interface is returned by calling
+/// [BluetoothRemoteGATTCharacteristic.properties].
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothCharacteristicProperties).
+extension type BluetoothCharacteristicProperties._(JSObject _)
+    implements JSObject {
+  /// The **`broadcast`** read-only property of the
+  /// [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if the broadcast of the characteristic
+  /// value is permitted using the Server Characteristic Configuration
+  /// Descriptor.
+  external bool get broadcast;
+
+  /// The **`read`** read-only property of the
+  /// [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if the reading of the characteristic
+  /// value is permitted.
+  external bool get read;
+
+  /// The **`writeWithoutResponse`** read-only
+  /// property of the [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if the writing to the characteristic
+  /// without response is permitted.
+  external bool get writeWithoutResponse;
+
+  /// The **`write`** read-only property of the
+  /// [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if the writing to the characteristic with
+  /// response is permitted.
+  external bool get write;
+
+  /// The **`notify`** read-only property of the
+  /// [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if notifications of the characteristic
+  /// value without acknowledgement is permitted.
+  external bool get notify;
+
+  /// The **`indicate`** read-only property of the
+  /// [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if indications of the characteristic
+  /// value with acknowledgement is permitted.
+  external bool get indicate;
+
+  /// The **`authenticatedSignedWrites`** read-only
+  /// property of the [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if signed writing to the characteristic
+  /// value is permitted.
+  external bool get authenticatedSignedWrites;
+
+  /// The **`reliableWrite`** read-only property of
+  /// the [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if reliable writes to the characteristic
+  /// is permitted.
+  external bool get reliableWrite;
+
+  /// The **`writableAuxiliaries`** read-only
+  /// property of the [BluetoothCharacteristicProperties] interface returns a
+  /// `boolean` that is `true` if reliable writes to the characteristic
+  /// descriptor is permitted.
+  external bool get writableAuxiliaries;
+}
+
+/// The `BluetoothRemoteGATTDescriptor` interface of the
+/// [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API)
+/// provides a GATT Descriptor,
+/// which provides further information about a characteristic's value.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTDescriptor).
+extension type BluetoothRemoteGATTDescriptor._(JSObject _) implements JSObject {
+  /// The
+  /// **`BluetoothRemoteGATTDescriptor.readValue()`**
+  /// method returns a `Promise` that resolves to
+  /// an `ArrayBuffer` holding a duplicate of the `value` property if
+  /// it is available and supported. Otherwise it throws an error.
+  external JSPromise<JSDataView> readValue();
+
+  /// The **`BluetoothRemoteGATTDescriptor.writeValue()`**
+  /// method sets the value property to the bytes contained in
+  /// an `ArrayBuffer` and returns a `Promise`.
+  external JSPromise<JSAny?> writeValue(BufferSource value);
+
+  /// The **`BluetoothRemoteGATTDescriptor.characteristic`**
+  /// read-only property returns the [BluetoothRemoteGATTCharacteristic] this
+  /// descriptor belongs to.
+  external BluetoothRemoteGATTCharacteristic get characteristic;
+
+  /// The **`BluetoothRemoteGATTDescriptor.uuid`** read-only property returns
+  /// the  of the characteristic descriptor.
+  /// For example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient
+  /// Characteristic Configuration descriptor.
+  external UUID get uuid;
+
+  /// The **`BluetoothRemoteGATTDescriptor.value`**
+  /// read-only property returns an `ArrayBuffer` containing the currently
+  /// cached
+  /// descriptor value. This value gets updated when the value of the descriptor
+  /// is read.
+  external JSDataView? get value;
+}
+
+/// The **`BluetoothUUID`** interface of the [Web Bluetooth API] provides a way
+/// to look up Universally Unique Identifier (UUID) values by name in the
+/// [registry](https://www.bluetooth.com/specifications/assigned-numbers/)
+/// maintained by the Bluetooth SIG.
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothUUID).
+extension type BluetoothUUID._(JSObject _) implements JSObject {
+  /// The **`getService()`** static method of the [BluetoothUUID] interface
+  /// returns a UUID representing a registered service when passed a name or the
+  /// 16- or 32-bit UUID alias.
+  external static UUID getService(JSAny name);
+
+  /// The **`getCharacteristic()`** static method of the [BluetoothUUID]
+  /// interface returns a UUID representing a registered characteristic when
+  /// passed a name or the 16- or 32-bit UUID alias.
+  external static UUID getCharacteristic(JSAny name);
+
+  /// The **`getDescriptor()`** static method of the [BluetoothUUID] interface
+  /// returns a UUID representing a registered descriptor when passed a name or
+  /// the 16- or 32-bit UUID alias.
+  external static UUID getDescriptor(JSAny name);
+
+  /// The **`canonicalUUID()`** static method of the [BluetoothUUID] interface
+  /// returns the 128-bit UUID when passed a 16- or 32-bit UUID alias.
+  external static UUID canonicalUUID(int alias);
+}

--- a/patches/flutter_blue_plus_web/lib/src/web_bluetooth.dart
+++ b/patches/flutter_blue_plus_web/lib/src/web_bluetooth.dart
@@ -15,7 +15,15 @@ library;
 
 import 'dart:js_interop';
 
-import 'package:web/web.dart' show AbortSignal, BufferSource, Event, EventHandler, EventInit, EventTarget, PermissionStatus;
+import 'package:web/web.dart'
+    show
+        AbortSignal,
+        BufferSource,
+        Event,
+        EventHandler,
+        EventInit,
+        EventTarget,
+        PermissionStatus;
 
 typedef UUID = String;
 typedef BluetoothServiceUUID = JSAny;

--- a/patches/flutter_blue_plus_web/pubspec.yaml
+++ b/patches/flutter_blue_plus_web/pubspec.yaml
@@ -1,0 +1,29 @@
+name: flutter_blue_plus_web
+description: Web implementation of the flutter_blue_plus plugin.
+version: 8.2.1
+homepage: https://github.com/chipweinberger/flutter_blue_plus
+
+environment:
+  sdk: ^3.3.0
+  flutter: '>=3.19.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_blue_plus_platform_interface: 8.2.1
+  flutter_web_plugins:
+    sdk: flutter
+  web: '>=0.5.0 <2.0.0'
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0
+
+flutter:
+  plugin:
+    implements: flutter_blue_plus
+    platforms:
+      web:
+        pluginClass: FlutterBluePlusWeb
+        fileName: flutter_blue_plus_web.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,12 @@ dependencies:
   web: ^1.1.1
   flutter_svg: ^2.0.10+1
 
+dependency_overrides:
+  # Web: return false from setNotifyValue so Dart does not wait for CCCD write
+  # (Chrome never sends that event), avoiding 15s timeout on connect.
+  flutter_blue_plus_web:
+    path: patches/flutter_blue_plus_web
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
I reworked the Chrome connection flow in a couple ways:

1. Changed the UI to be more intuitive since Chrome uses a native selector. There is no need for a `scan` button or a listing of BLE devices.

2. In the native Chrome BLE picker, we now filter by Nordic UART service ID because it is not possible to filter by `MeshCore-` prefix. tbh this seems like something we should probably do everywhere. I'm not sure why MC didn't choose their own service ID, it seems like that would clean up everything.

3. There is a bug in Flutter Blue that prevents the BLE handshake from working correctly on Chrome. That is fixed with a patch.

<img width="1200" height="1040" alt="image" src="https://github.com/user-attachments/assets/2ba6594b-a055-4bd2-822e-8dea649078c4" />

<img width="1200" height="1040" alt="image" src="https://github.com/user-attachments/assets/50d843d4-833b-4904-a138-1143b4c0a9be" />
