### PR TITLE
Align app start frame with firmware docs

### DIFF
--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -527,17 +527,15 @@ Uint8List buildRemoveContactFrame(Uint8List pubKey) {
 }
 
 // Build CMD_APP_START frame
-// Format: [cmd][app_ver][reserved x6][app_name...]
+// Format: [cmd][app_ver][app_name x9]
 Uint8List buildAppStartFrame({
-  String appName = 'MeshCoreOpen',
-  int appVersion = 1,
+  String appName = 'mccli',
+  int appVersion = appProtocolVersion,
 }) {
   final writer = BufferWriter();
   writer.writeByte(cmdAppStart);
   writer.writeByte(appVersion);
-  writer.writeBytes(Uint8List(6)); // reserved bytes
-  writer.writeString(appName);
-  writer.writeByte(0);
+  writer.writeCString(appName, 9);
   return writer.toBytes();
 }
 

--- a/test/connector/meshcore_protocol_test.dart
+++ b/test/connector/meshcore_protocol_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+
+void main() {
+  group('buildAppStartFrame', () {
+    test('uses the documented companion protocol layout by default', () {
+      final frame = buildAppStartFrame();
+
+      expect(
+        frame,
+        orderedEquals(<int>[
+          cmdAppStart,
+          appProtocolVersion,
+          0x6d,
+          0x63,
+          0x63,
+          0x6c,
+          0x69,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+        ]),
+      );
+    });
+
+    test('null pads or truncates the app identifier to 9 bytes', () {
+      final frame = buildAppStartFrame(appName: 'meshcore-open-client');
+
+      expect(frame.length, 11);
+      expect(
+        frame.sublist(2),
+        orderedEquals(<int>[0x6d, 0x65, 0x73, 0x68, 0x63, 0x6f, 0x72, 0x65, 0x00]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The app's `CMD_APP_START` frame did not match the firmware protocol documentation. The implementation sent a different layout and identifier string than the documented companion handshake. That creates a protocol-level incompatibility during startup and makes device identification dependent on undocumented firmware tolerance.

## Fix

Change the app-start frame builder to emit the documented wire format: protocol version byte followed by the companion identifier in the expected fixed-width, null-padded field.

Add protocol tests that verify:
- the default frame bytes are exactly correct
- shorter names are null-padded correctly
- longer names are truncated correctly

## Why this fixes it

The startup command now matches the firmware contract at the byte level, so devices parsing `CMD_APP_START` according to the docs receive the expected identifier and field layout. This removes ambiguity from the initial handshake and makes behavior deterministic across firmware versions that follow the documented protocol.

## Tradeoffs

This intentionally stops advertising the previous custom app identifier on the wire. If any downstream tooling depended on the old undocumented format, it will no longer see it. The change favors protocol conformance and interoperability over preserving app-specific wire behavior.
