### PR TITLE
Route reboot through documented cli frame

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -2068,12 +2068,8 @@ class MeshCoreConnector extends ChangeNotifier {
 
   Future<void> sendCliCommand(String command) async {
     if (!isConnected) return;
-
-    // CLI commands are sent as UTF-8 text with a special prefix
-    final commandBytes = utf8.encode(command);
-    final bytes = Uint8List.fromList([0x01, ...commandBytes, 0x00]);
     _lastSentWasCliCommand = true;
-    await sendFrame(bytes);
+    await sendFrame(buildLocalCliCommandFrame(command));
   }
 
   Future<void> setNodeName(String name) async {
@@ -2101,7 +2097,7 @@ class MeshCoreConnector extends ChangeNotifier {
 
   Future<void> rebootDevice() async {
     if (!isConnected) return;
-    await sendFrame(buildRebootFrame());
+    await sendCliCommand('reboot');
   }
 
   Future<void> setPrivacyMode(bool enabled) async {

--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -601,10 +601,10 @@ Uint8List buildSetCustomVarFrame(String value) {
   return writer.toBytes();
 }
 
-// Build CMD_REBOOT frame
-// Format: [cmd]["reboot"]
-Uint8List buildRebootFrame() {
-  return Uint8List.fromList([cmdReboot, ...utf8.encode('reboot')]);
+// Build local CLI command frame
+// Format: [cmdAppStart][command...]\0
+Uint8List buildLocalCliCommandFrame(String command) {
+  return Uint8List.fromList([cmdAppStart, ...utf8.encode(command), 0]);
 }
 
 // Build CMD_SYNC_NEXT_MESSAGE frame

--- a/test/connector/meshcore_protocol_test.dart
+++ b/test/connector/meshcore_protocol_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+
+void main() {
+  group('buildLocalCliCommandFrame', () {
+    test('encodes local cli commands with the documented raw format', () {
+      final frame = buildLocalCliCommandFrame('reboot');
+
+      expect(
+        frame,
+        orderedEquals(<int>[cmdAppStart, 0x72, 0x65, 0x62, 0x6f, 0x6f, 0x74, 0x00]),
+      );
+    });
+
+    test('preserves spaces and null-terminates the command', () {
+      final frame = buildLocalCliCommandFrame('set privacy on');
+
+      expect(frame.first, cmdAppStart);
+      expect(frame.last, 0);
+      expect(
+        String.fromCharCodes(frame.sublist(1, frame.length - 1)),
+        'set privacy on',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The app exposed a reboot action that sent a dedicated reboot frame format not described in the firmware docs. The documented reboot path is a CLI command, not a special binary reboot packet. As implemented, the UI could send a reboot request that firmware following the docs would not recognize.

## Fix

Remove the bespoke reboot frame path and send reboot through the documented local CLI command format instead. Reuse the same command path for `sendCliCommand()` and `rebootDevice()` so reboot is encoded identically to other local CLI commands.

Add protocol tests that verify the raw local CLI frame format.

## Why this fixes it

The reboot action now uses the documented command path the firmware already understands. That means the settings action is no longer dependent on an undocumented or stale reboot opcode format and should work on firmware that implements the CLI contract from the docs.

## Tradeoffs

This consolidates reboot behavior onto the CLI transport, so reboot now inherits the same constraints as other CLI commands. That is the correct tradeoff because it removes a parallel, undocumented path and reduces protocol drift.
