### PR TITLE
Align channel frames with firmware secret format

### DIFF
--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart' as crypto;
+
 // Buffer Reader - sequential binary data reader with pointer tracking
 class BufferReader {
   int _pointer = 0;
@@ -618,19 +620,30 @@ Uint8List buildGetChannelFrame(int channelIndex) {
 }
 
 // Build CMD_SET_CHANNEL frame
-// Format: [cmd][idx][name x32][psk x16]
+// Format: [cmd][idx][name x32][secret x32]
 Uint8List buildSetChannelFrame(int channelIndex, String name, Uint8List psk) {
   final writer = BufferWriter();
   writer.writeByte(cmdSetChannel);
   writer.writeByte(channelIndex);
   writer.writeCString(name, 32);
-  // Write PSK (16 bytes, zero-padded)
-  final pskPadded = Uint8List(16);
-  for (int i = 0; i < 16 && i < psk.length; i++) {
-    pskPadded[i] = psk[i];
-  }
-  writer.writeBytes(pskPadded);
+  writer.writeBytes(_expandChannelSecretForDevice(psk));
   return writer.toBytes();
+}
+
+Uint8List _expandChannelSecretForDevice(Uint8List psk) {
+  if (psk.length >= 32) {
+    return Uint8List.fromList(psk.sublist(0, 32));
+  }
+
+  final padded = Uint8List(16);
+  final copyLength = psk.length < 16 ? psk.length : 16;
+  padded.setRange(0, copyLength, psk);
+  if (padded.every((byte) => byte == 0)) {
+    return Uint8List(32);
+  }
+
+  final digest = crypto.sha512.convert(padded).bytes;
+  return Uint8List.fromList(digest.sublist(0, 32));
 }
 
 // Build CMD_SET_RADIO_PARAMS frame

--- a/lib/models/channel.dart
+++ b/lib/models/channel.dart
@@ -29,13 +29,20 @@ class Channel {
     // [0] = RESP_CODE_CHANNEL_INFO (18)
     // [1] = channel_idx
     // [2-33] = name (32 bytes, null-terminated)
-    // [34-49] = psk (16 bytes)
-    if (data.length < 50) return null;
+    // [34-65] = secret (32 bytes, may be omitted or truncated by device)
+    if (data.length < 34) return null;
     if (data[0] != respCodeChannelInfo) return null;
 
     final index = data[1];
     final name = readCString(data, 2, 32);
-    final psk = Uint8List.fromList(data.sublist(34, 50));
+    final psk = Uint8List(16);
+    if (data.length > 34) {
+      final availableSecretBytes = data.length - 34;
+      final secretCopyLength = availableSecretBytes < 16
+          ? availableSecretBytes
+          : 16;
+      psk.setRange(0, secretCopyLength, data.sublist(34, 34 + secretCopyLength));
+    }
 
     return Channel(index: index, name: name, psk: psk);
   }

--- a/test/connector/meshcore_protocol_test.dart
+++ b/test/connector/meshcore_protocol_test.dart
@@ -1,0 +1,61 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+import 'package:meshcore_open/models/channel.dart';
+
+void main() {
+  group('buildSetChannelFrame', () {
+    test('expands a 16-byte local secret to the documented 32-byte device field', () {
+      final psk = Uint8List.fromList(List<int>.generate(16, (index) => index + 1));
+
+      final frame = buildSetChannelFrame(2, 'Ops', psk);
+      final expectedSecret = crypto.sha512.convert(psk).bytes.sublist(0, 32);
+
+      expect(frame.length, 66);
+      expect(frame[0], cmdSetChannel);
+      expect(frame[1], 2);
+      expect(frame.sublist(34, 66), orderedEquals(expectedSecret));
+    });
+
+    test('keeps the public channel secret as all zeros', () {
+      final frame = buildSetChannelFrame(0, 'Public', Uint8List(16));
+
+      expect(frame.length, 66);
+      expect(frame.sublist(34, 66), everyElement(0));
+    });
+  });
+
+  group('Channel.fromFrame', () {
+    test('parses truncated channel info responses without a secret', () {
+      final data = Uint8List(34)
+        ..[0] = respCodeChannelInfo
+        ..[1] = 4;
+      final nameBytes = 'Scout'.codeUnits;
+      data.setRange(2, 2 + nameBytes.length, nameBytes);
+
+      final channel = Channel.fromFrame(data);
+
+      expect(channel, isNotNull);
+      expect(channel!.index, 4);
+      expect(channel.name, 'Scout');
+      expect(channel.psk, orderedEquals(Uint8List(16)));
+    });
+
+    test('retains the first 16 bytes when a secret is present', () {
+      final data = Uint8List(66)
+        ..[0] = respCodeChannelInfo
+        ..[1] = 1;
+      final nameBytes = 'Field'.codeUnits;
+      data.setRange(2, 2 + nameBytes.length, nameBytes);
+      final secret = List<int>.generate(32, (index) => index + 11);
+      data.setRange(34, 66, secret);
+
+      final channel = Channel.fromFrame(data);
+
+      expect(channel, isNotNull);
+      expect(channel!.psk, orderedEquals(secret.sublist(0, 16)));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Channel handling diverged from the firmware docs in two ways:
1. channel set frames were sending a 16-byte secret even though the documented device-side field is 32 bytes
2. channel info parsing assumed a full secret would always be present, even though the docs explicitly allow the returned frame to omit the secret

Those mismatches risk failed channel writes and dropped channel reads on firmware that follows the documented format.

## Fix

Update channel write encoding to populate the documented 32-byte device secret field. Preserve the app's 16-byte local PSK model by deriving the device-side 32-byte representation deterministically from the local secret, while preserving all-zero public-channel behavior.

Relax channel info parsing so truncated frames without a returned secret are still accepted. When secret bytes are present, retain the compatible local representation.

Add tests that verify:
- deterministic expansion of a local 16-byte secret into the device field
- all-zero public channel behavior
- parsing of truncated channel info responses
- parsing of longer responses that include secret bytes

## Why this fixes it

The app now writes a frame shape the firmware docs describe and no longer rejects valid shorter channel-info responses. This restores compatibility in both directions: channel configuration requests use the documented width, and channel reads tolerate documented omission of secret material.

## Tradeoffs

The app still stores a 16-byte local PSK even though the device field is 32 bytes. That is deliberate to avoid a larger data model migration. The compatibility layer adds a derivation step, which is slightly more complex than a direct byte copy, but keeps existing app behavior stable while aligning the wire format.
