### PR TITLE
Buffer fragmented BLE notification frames

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -138,15 +138,18 @@ class MeshCoreConnector extends ChangeNotifier {
   StreamSubscription<BluetoothConnectionState>? _connectionSubscription;
   StreamSubscription<List<int>>? _notifySubscription;
   Timer? _notifyListenersTimer;
+  Timer? _bleFrameFlushTimer;
   Timer? _selfInfoRetryTimer;
   Timer? _reconnectTimer;
   Timer? _batteryPollTimer;
   int _reconnectAttempts = 0;
   bool _notifyListenersDirty = false;
   static const Duration _notifyListenersDebounce = Duration(milliseconds: 50);
+  static const Duration _bleFrameFlushDelay = Duration(milliseconds: 20);
 
   final StreamController<Uint8List> _receivedFramesController =
       StreamController<Uint8List>.broadcast();
+  final MeshCoreFrameBuffer _bleFrameBuffer = MeshCoreFrameBuffer();
 
   Uint8List? _selfPublicKey;
   String? _selfName;
@@ -918,7 +921,7 @@ class MeshCoreConnector extends ChangeNotifier {
       }
       await Future<void>.delayed(const Duration(milliseconds: 200));
       _usbFrameSubscription = _usbManager.frameStream.listen(
-        _handleFrame,
+        _dispatchFrame,
         onError: (error, stackTrace) {
           _appDebugLogService?.error('USB transport error: $error', tag: 'USB');
           unawaited(disconnect(manual: false));
@@ -1136,7 +1139,7 @@ class MeshCoreConnector extends ChangeNotifier {
         }
       }
       _notifySubscription = _txCharacteristic!.onValueReceived.listen(
-        _handleFrame,
+        _handleBleNotification,
       );
 
       _setState(MeshCoreConnectionState.connected);
@@ -1306,6 +1309,9 @@ class MeshCoreConnector extends ChangeNotifier {
     _connectionSubscription = null;
     _selfInfoRetryTimer?.cancel();
     _selfInfoRetryTimer = null;
+    _bleFrameFlushTimer?.cancel();
+    _bleFrameFlushTimer = null;
+    _bleFrameBuffer.clear();
     _queueSyncTimeout?.cancel();
     _queueSyncTimeout = null;
     _queueSyncRetries = 0;
@@ -2281,10 +2287,26 @@ class MeshCoreConnector extends ChangeNotifier {
     await getChannels(force: true);
   }
 
-  void _handleFrame(List<int> data) {
+  void _handleBleNotification(List<int> data) {
     if (data.isEmpty) return;
 
-    final frame = Uint8List.fromList(data);
+    final frames = _bleFrameBuffer.addChunk(Uint8List.fromList(data));
+    for (final frame in frames) {
+      _dispatchFrame(frame);
+    }
+
+    _bleFrameFlushTimer?.cancel();
+    if (_bleFrameBuffer.hasBufferedData) {
+      _bleFrameFlushTimer = Timer(_bleFrameFlushDelay, () {
+        final flushed = _bleFrameBuffer.flush();
+        if (flushed != null) {
+          _dispatchFrame(flushed);
+        }
+      });
+    }
+  }
+
+  void _dispatchFrame(Uint8List frame) {
     _receivedFramesController.add(frame);
     _bleDebugLogService?.logFrame(frame, outgoing: false);
 
@@ -4150,6 +4172,9 @@ class MeshCoreConnector extends ChangeNotifier {
     _notifySubscription = null;
     _connectionSubscription?.cancel();
     _connectionSubscription = null;
+    _bleFrameFlushTimer?.cancel();
+    _bleFrameFlushTimer = null;
+    _bleFrameBuffer.clear();
 
     _device = null;
     _rxCharacteristic = null;
@@ -4276,6 +4301,7 @@ class MeshCoreConnector extends ChangeNotifier {
     _usbFrameSubscription?.cancel();
     _notifySubscription?.cancel();
     _notifyListenersTimer?.cancel();
+    _bleFrameFlushTimer?.cancel();
     _reconnectTimer?.cancel();
     _batteryPollTimer?.cancel();
     _receivedFramesController.close();

--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -361,6 +361,90 @@ class ParsedContactText {
   const ParsedContactText({required this.senderPrefix, required this.text});
 }
 
+class MeshCoreFrameBuffer {
+  final BytesBuilder _buffer = BytesBuilder(copy: false);
+
+  bool get hasBufferedData => _buffer.length > 0;
+
+  List<Uint8List> addChunk(Uint8List chunk) {
+    if (chunk.isNotEmpty) {
+      _buffer.add(chunk);
+    }
+    return _drainCompleteFrames();
+  }
+
+  Uint8List? flush() {
+    if (!hasBufferedData) {
+      return null;
+    }
+    final data = _buffer.toBytes();
+    clear();
+    return data;
+  }
+
+  void clear() {
+    _buffer.clear();
+  }
+
+  List<Uint8List> _drainCompleteFrames() {
+    final frames = <Uint8List>[];
+
+    while (true) {
+      final buffered = _buffer.toBytes();
+      if (buffered.isEmpty) {
+        break;
+      }
+
+      final frameLength = _expectedFrameLength(buffered);
+      if (frameLength == null || buffered.length < frameLength) {
+        break;
+      }
+
+      frames.add(Uint8List.fromList(buffered.sublist(0, frameLength)));
+      _replaceBuffer(buffered.sublist(frameLength));
+    }
+
+    return frames;
+  }
+
+  void _replaceBuffer(List<int> bytes) {
+    _buffer.clear();
+    if (bytes.isNotEmpty) {
+      _buffer.add(bytes);
+    }
+  }
+
+  int? _expectedFrameLength(Uint8List data) {
+    if (data.isEmpty) return null;
+
+    switch (data[0]) {
+      case respCodeContactsStart:
+      case respCodeEndOfContacts:
+      case respCodeNoMoreMessages:
+      case pushCodeMsgWaiting:
+      case pushCodeLoginSuccess:
+      case pushCodeLoginFail:
+        return 1;
+      case respCodeCurrTime:
+        return 5;
+      case respCodeSent:
+        return 10;
+      case respCodeContact:
+      case pushCodeNewAdvert:
+        return contactFrameSize;
+      case pushCodePathUpdated:
+        return 33;
+      case respCodeAutoAddConfig:
+        return 2;
+      case pushCodeSendConfirmed:
+        if (data.length >= 9) return 9;
+        return null;
+      default:
+        return null;
+    }
+  }
+}
+
 ParsedContactText? parseContactMessageText(Uint8List frame) {
   if (frame.isEmpty) return null;
   final code = frame[0];

--- a/test/connector/frame_buffer_test.dart
+++ b/test/connector/frame_buffer_test.dart
@@ -1,0 +1,63 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+
+void main() {
+  group('MeshCoreFrameBuffer', () {
+    test('reassembles a split fixed-length sent packet', () {
+      final buffer = MeshCoreFrameBuffer();
+      final frame = Uint8List.fromList(<int>[
+        respCodeSent,
+        1,
+        0xAA,
+        0xBB,
+        0xCC,
+        0xDD,
+        0x10,
+        0x00,
+        0x00,
+        0x00,
+      ]);
+
+      expect(buffer.addChunk(frame.sublist(0, 4)), isEmpty);
+
+      final frames = buffer.addChunk(frame.sublist(4));
+      expect(frames, hasLength(1));
+      expect(frames.single, orderedEquals(frame));
+    });
+
+    test('splits multiple fixed-length packets from one chunk', () {
+      final buffer = MeshCoreFrameBuffer();
+      final payload = Uint8List.fromList(<int>[
+        respCodeCurrTime,
+        0x78,
+        0x56,
+        0x34,
+        0x12,
+        pushCodeMsgWaiting,
+      ]);
+
+      final frames = buffer.addChunk(payload);
+      expect(frames, hasLength(2));
+      expect(frames[0], orderedEquals(payload.sublist(0, 5)));
+      expect(frames[1], orderedEquals(<int>[pushCodeMsgWaiting]));
+    });
+
+    test('flushes buffered variable-length data as a single frame', () {
+      final buffer = MeshCoreFrameBuffer();
+      final frame = Uint8List.fromList(<int>[
+        respCodeCustomVars,
+        ...'k=v'.codeUnits,
+      ]);
+
+      expect(buffer.addChunk(frame.sublist(0, 2)), isEmpty);
+      expect(buffer.addChunk(frame.sublist(2)), isEmpty);
+
+      final flushed = buffer.flush();
+      expect(flushed, isNotNull);
+      expect(flushed!, orderedEquals(frame));
+      expect(buffer.hasBufferedData, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The connector assumed each BLE notification already contained exactly one complete MeshCore frame. The firmware docs explicitly warn that BLE notifications can arrive in chunks, especially for larger packets. Under fragmentation, the app could misparse packets, drop frames, or treat partial payloads as complete protocol messages.

## Fix

Add a small frame buffer for BLE notifications that:
- immediately emits complete fixed-length packets when enough bytes are available
- accumulates incomplete data across notifications
- flushes variable-length buffered data after a short debounce so multi-notification packets can be reassembled without stalling indefinitely

Keep USB behavior on direct frame dispatch because the USB transport already supplies framed messages.

Add tests that verify:
- reassembly of a split fixed-length packet
- extraction of multiple fixed-length packets from one chunk
- flush behavior for variable-length buffered data

## Why this fixes it

The connector no longer assumes notification boundaries equal protocol boundaries. Fixed-size packets are reconstructed deterministically, and variable-length packets are given a bounded opportunity to arrive in multiple chunks before dispatch. That matches the firmware docs' buffering requirement and prevents a class of parsing failures on fragmented BLE traffic.

## Tradeoffs

Variable-length frame recovery uses a short timed flush rather than a full length-prefixed parser for every packet type. That keeps the change small and low-risk, but it is heuristic-based for packets whose size is not explicitly derivable from the leading bytes. It materially improves correctness without requiring a full protocol framing redesign.
