### PR TITLE
Normalize ack packet parsing to firmware docs

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -3275,15 +3275,10 @@ class MeshCoreConnector extends ChangeNotifier {
   }
 
   void _handleMessageSent(Uint8List frame) {
-    // Frame format from C++:
-    // [0] = RESP_CODE_SENT
-    // [1] = is_flood (1 or 0)
-    // [2-5] = expected_ack_hash (uint32)
-    // [6-9] = estimated_timeout_ms (uint32)
-
-    if (frame.length >= 10) {
-      final ackHash = Uint8List.fromList(frame.sublist(2, 6));
-      final timeoutMs = readUint32LE(frame, 6);
+    final packet = parseMessageSentPacket(frame);
+    if (packet != null) {
+      final ackHash = packet.expectedAck;
+      final timeoutMs = packet.suggestedTimeoutMs;
 
       // Check if this is a CLI command ACK - if so, ignore it
       if (_lastSentWasCliCommand) {
@@ -3390,14 +3385,12 @@ class MeshCoreConnector extends ChangeNotifier {
   }
 
   void _handleSendConfirmed(Uint8List frame) {
-    // Frame format from C++:
-    // [0] = PUSH_CODE_SEND_CONFIRMED
-    // [1-4] = ack_hash (uint32)
-    // [5-8] = trip_time_ms (uint32)
-
-    if (frame.length >= 9) {
-      final ackHash = Uint8List.fromList(frame.sublist(1, 5));
-      final tripTimeMs = readUint32LE(frame, 5);
+    final packet = parseAckPacket(frame);
+    if (packet != null) {
+      final ackHash = packet.ackCode.length >= 4
+          ? Uint8List.fromList(packet.ackCode.sublist(0, 4))
+          : packet.ackCode;
+      final tripTimeMs = packet.tripTimeMs ?? 0;
 
       // CLI command ACKs are already filtered in _handleMessageSent, so this should only see real messages
 

--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -361,6 +361,56 @@ class ParsedContactText {
   const ParsedContactText({required this.senderPrefix, required this.text});
 }
 
+class MessageSentPacket {
+  final int messageType;
+  final Uint8List expectedAck;
+  final int suggestedTimeoutMs;
+
+  const MessageSentPacket({
+    required this.messageType,
+    required this.expectedAck,
+    required this.suggestedTimeoutMs,
+  });
+}
+
+MessageSentPacket? parseMessageSentPacket(Uint8List frame) {
+  if (frame.length < 10 || frame[0] != respCodeSent) {
+    return null;
+  }
+
+  return MessageSentPacket(
+    messageType: frame[1],
+    expectedAck: Uint8List.fromList(frame.sublist(2, 6)),
+    suggestedTimeoutMs: readUint32LE(frame, 6) * 1000,
+  );
+}
+
+class AckPacket {
+  final Uint8List ackCode;
+  final int? tripTimeMs;
+
+  const AckPacket({required this.ackCode, this.tripTimeMs});
+}
+
+AckPacket? parseAckPacket(Uint8List frame) {
+  if (frame.length < 5 || frame[0] != pushCodeSendConfirmed) {
+    return null;
+  }
+
+  if (frame.length >= 9) {
+    return AckPacket(
+      ackCode: Uint8List.fromList(frame.sublist(1, 5)),
+      tripTimeMs: readUint32LE(frame, 5),
+    );
+  }
+
+  if (frame.length >= 7) {
+    return AckPacket(ackCode: Uint8List.fromList(frame.sublist(1, 7)));
+  }
+
+  return null;
+}
+
 ParsedContactText? parseContactMessageText(Uint8List frame) {
   if (frame.isEmpty) return null;
   final code = frame[0];

--- a/test/connector/ack_packet_test.dart
+++ b/test/connector/ack_packet_test.dart
@@ -1,0 +1,70 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+
+void main() {
+  group('parseMessageSentPacket', () {
+    test('converts documented timeout seconds to milliseconds', () {
+      final frame = Uint8List.fromList(<int>[
+        respCodeSent,
+        1,
+        0x11,
+        0x22,
+        0x33,
+        0x44,
+        5,
+        0,
+        0,
+        0,
+      ]);
+
+      final packet = parseMessageSentPacket(frame);
+
+      expect(packet, isNotNull);
+      expect(packet!.messageType, 1);
+      expect(packet.expectedAck, orderedEquals(<int>[0x11, 0x22, 0x33, 0x44]));
+      expect(packet.suggestedTimeoutMs, 5000);
+    });
+  });
+
+  group('parseAckPacket', () {
+    test('parses the documented 6-byte ack code variant', () {
+      final frame = Uint8List.fromList(<int>[
+        pushCodeSendConfirmed,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+      ]);
+
+      final packet = parseAckPacket(frame);
+
+      expect(packet, isNotNull);
+      expect(packet!.ackCode, orderedEquals(<int>[1, 2, 3, 4, 5, 6]));
+      expect(packet.tripTimeMs, isNull);
+    });
+
+    test('parses the extended ack variant with trip time', () {
+      final frame = Uint8List.fromList(<int>[
+        pushCodeSendConfirmed,
+        0xaa,
+        0xbb,
+        0xcc,
+        0xdd,
+        0x10,
+        0x27,
+        0x00,
+        0x00,
+      ]);
+
+      final packet = parseAckPacket(frame);
+
+      expect(packet, isNotNull);
+      expect(packet!.ackCode, orderedEquals(<int>[0xaa, 0xbb, 0xcc, 0xdd]));
+      expect(packet.tripTimeMs, 10000);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The implementation treated `PACKET_MSG_SENT` timeout values and `PACKET_ACK` layout according to older assumptions:
- the send timeout was treated as milliseconds instead of documented seconds
- acknowledgements were assumed to always carry a 4-byte hash plus trip time

The firmware docs describe a different contract, including a shorter ACK variant. That mismatch can distort retry timing and make ACK handling incompatible with documented firmware behavior.

## Fix

Add dedicated parsers for:
- message-sent packets, converting the documented timeout units into milliseconds for internal use
- ACK packets, supporting both the documented short ACK form and the extended variant with trip time

Refactor connector handling to use those parsers instead of hard-coded offsets.

Add tests that verify:
- documented timeout conversion
- parsing of the documented short ACK variant
- parsing of the extended ACK variant

## Why this fixes it

Retry and delivery handling now normalize documented wire values into the app's internal model instead of assuming a single legacy frame shape. That preserves internal behavior while accepting the protocol formats described by firmware docs, which improves interoperability and timing correctness.

## Tradeoffs

For compatibility with existing internal ACK tracking, the short ACK variant is reduced to the first 4 bytes where the rest of the app still expects a 4-byte key. That keeps the change bounded, but it means the app is not yet using the full 6-byte ACK value end-to-end.
