### PR TITLE
Interpret battery packets as documented percent values

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -159,6 +159,7 @@ class MeshCoreConnector extends ChangeNotifier {
   bool? _clientRepeat;
   int? _firmwareVerCode;
   int? _batteryMillivolts;
+  int? _batteryPercentValue;
   double? _selfLatitude;
   double? _selfLongitude;
   final List<DirectRepeater> _directRepeaters = List.empty(growable: true);
@@ -310,6 +311,7 @@ class MeshCoreConnector extends ChangeNotifier {
   int? get firmwareVerCode => _firmwareVerCode;
   Map<String, String>? get currentCustomVars => _currentCustomVars;
   int? get batteryMillivolts => _batteryMillivolts;
+  bool get hasBatteryVoltage => _batteryMillivolts != null;
   int get maxContacts => _maxContacts;
   int get maxChannels => _maxChannels;
   Set<String> get knownContactKeys => Set.unmodifiable(_knownContactKeys);
@@ -319,12 +321,12 @@ class MeshCoreConnector extends ChangeNotifier {
       _isSyncingChannels && _totalChannelsToRequest > 0
       ? ((_nextChannelIndexToRequest / _totalChannelsToRequest) * 100).round()
       : 0;
-  int? get batteryPercent => _batteryMillivolts == null
+  int? get batteryPercent => _batteryPercentValue ?? (_batteryMillivolts == null
       ? null
       : estimateBatteryPercentFromMillivolts(
           _batteryMillivolts!,
           _batteryChemistryForDevice(),
-        );
+        ));
   RepeaterBatterySnapshot? getRepeaterBatterySnapshot(String contactKeyHex) =>
       _repeaterBatterySnapshots[contactKeyHex];
   int? getRepeaterBatteryMillivolts(String contactKeyHex) =>
@@ -1336,6 +1338,7 @@ class MeshCoreConnector extends ChangeNotifier {
     _clientRepeat = null;
     _firmwareVerCode = null;
     _batteryMillivolts = null;
+    _batteryPercentValue = null;
     _repeaterBatterySnapshots.clear();
     _batteryRequested = false;
     _awaitingSelfInfo = false;
@@ -2588,20 +2591,16 @@ class MeshCoreConnector extends ChangeNotifier {
   }
 
   void _handleBatteryAndStorage(Uint8List frame) {
-    // Frame format from C++:
-    // [0] = RESP_CODE_BATT_AND_STORAGE
-    // [1-2] = battery_mv (uint16 LE)
-    // [3-6] = storage_used_kb (uint32 LE)
-    // [7-10] = storage_total_kb (uint32 LE)
-    if (frame.length >= 3) {
-      _batteryMillivolts = readUint16LE(frame, 1);
-      final volts = (_batteryMillivolts! / 1000.0).toStringAsFixed(2);
-      _appDebugLogService?.info(
-        'Pulled battery: $volts V ($_batteryMillivolts mV)',
-        tag: 'Battery',
-      );
-      notifyListeners();
-    }
+    final packet = parseBatteryStatusPacket(frame);
+    if (packet == null) return;
+
+    _batteryPercentValue = packet.levelPercent.clamp(0, 100);
+    _batteryMillivolts = null;
+    _appDebugLogService?.info(
+      'Pulled battery level: ${_batteryPercentValue!}%',
+      tag: 'Battery',
+    );
+    notifyListeners();
   }
 
   void _checkManualAddContacts() async {

--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -361,6 +361,32 @@ class ParsedContactText {
   const ParsedContactText({required this.senderPrefix, required this.text});
 }
 
+class BatteryStatusPacket {
+  final int levelPercent;
+  final int? usedStorageKb;
+  final int? totalStorageKb;
+
+  const BatteryStatusPacket({
+    required this.levelPercent,
+    this.usedStorageKb,
+    this.totalStorageKb,
+  });
+}
+
+BatteryStatusPacket? parseBatteryStatusPacket(Uint8List frame) {
+  if (frame.length < 3 || frame[0] != respCodeBattAndStorage) {
+    return null;
+  }
+
+  final levelPercent = readUint16LE(frame, 1);
+  final hasStorage = frame.length >= 11;
+  return BatteryStatusPacket(
+    levelPercent: levelPercent,
+    usedStorageKb: hasStorage ? readUint32LE(frame, 3) : null,
+    totalStorageKb: hasStorage ? readUint32LE(frame, 7) : null,
+  );
+}
+
 ParsedContactText? parseContactMessageText(Uint8List frame) {
   if (frame.isEmpty) return null;
   final code = frame[0];

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -174,16 +174,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     // figure out display value
     final String displayValue;
-    if (millivolts == null) {
+    if (percent != null && !_showBatteryVoltage) {
+      displayValue = l10n.common_percentValue(percent);
+    } else if (millivolts == null) {
       displayValue = l10n.common_notAvailable;
     } else if (_showBatteryVoltage) {
       displayValue = l10n.common_voltageValue(
         (millivolts / 1000.0).toStringAsFixed(2),
       );
     } else {
-      displayValue = percent != null
-          ? l10n.common_percentValue(percent)
-          : l10n.common_notAvailable;
+      displayValue = l10n.common_notAvailable;
     }
 
     final IconData icon;

--- a/lib/widgets/battery_indicator.dart
+++ b/lib/widgets/battery_indicator.dart
@@ -43,12 +43,12 @@ class _BatteryIndicatorState extends State<BatteryIndicator> {
     final percent = widget.connector.batteryPercent;
     final millivolts = widget.connector.batteryMillivolts;
 
-    if (millivolts == null) {
+    if (percent == null && millivolts == null) {
       return const SizedBox.shrink();
     }
 
     final String displayText;
-    if (_showBatteryVoltage) {
+    if (_showBatteryVoltage && millivolts != null) {
       displayText = '${(millivolts / 1000.0).toStringAsFixed(2)}V';
     } else {
       displayText = percent != null ? '$percent%' : '—';
@@ -57,11 +57,13 @@ class _BatteryIndicatorState extends State<BatteryIndicator> {
     final batteryUi = batteryUiForPercent(percent);
 
     return InkWell(
-      onTap: () {
-        setState(() {
-          _showBatteryVoltage = !_showBatteryVoltage;
-        });
-      },
+      onTap: millivolts == null
+          ? null
+          : () {
+              setState(() {
+                _showBatteryVoltage = !_showBatteryVoltage;
+              });
+            },
       borderRadius: BorderRadius.circular(8),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),

--- a/test/connector/battery_packet_test.dart
+++ b/test/connector/battery_packet_test.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_connector.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+import 'package:meshcore_open/widgets/battery_indicator.dart';
+
+void main() {
+  group('parseBatteryStatusPacket', () {
+    test('parses battery percentage and optional storage fields', () {
+      final frame = Uint8List.fromList(<int>[
+        respCodeBattAndStorage,
+        75,
+        0,
+        0x34,
+        0x12,
+        0x00,
+        0x00,
+        0x78,
+        0x56,
+        0x00,
+        0x00,
+      ]);
+
+      final packet = parseBatteryStatusPacket(frame);
+
+      expect(packet, isNotNull);
+      expect(packet!.levelPercent, 75);
+      expect(packet.usedStorageKb, 0x1234);
+      expect(packet.totalStorageKb, 0x5678);
+    });
+  });
+
+  testWidgets('BatteryIndicator renders percentage when voltage is unavailable', (
+    tester,
+  ) async {
+    final connector = _FakeConnector(63);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BatteryIndicator(connector: connector),
+        ),
+      ),
+    );
+
+    expect(find.text('63%'), findsOneWidget);
+  });
+}
+
+class _FakeConnector extends MeshCoreConnector {
+  _FakeConnector(this._batteryPercent);
+
+  final int _batteryPercent;
+
+  @override
+  int? get batteryPercent => _batteryPercent;
+
+  @override
+  int? get batteryMillivolts => null;
+}


### PR DESCRIPTION
## Problem

The app interpreted battery packets as millivolts and derived percentage from voltage heuristics. The firmware docs describe that packet as a battery percentage value, optionally followed by storage counters. If the docs are authoritative, the UI was displaying incorrect battery information and mixing protocol parsing with device-specific voltage estimation.

## Fix

Parse the battery packet according to the documented percentage format and store the reported percentage directly. Keep voltage-dependent UI behavior behind an explicit "has voltage" check so the app still renders cleanly when only percentage is available.

Add tests that verify:
- documented battery packet parsing
- optional storage parsing behavior
- UI rendering of battery percentage without requiring a voltage value

## Why this fixes it

The app now displays the battery value the firmware actually reports instead of inventing a voltage interpretation from the same bytes. That makes the battery UI consistent with the documented protocol and removes chemistry-specific estimation from a packet that is already a percentage.

## Tradeoffs

This change gives up inferred voltage display for this packet format. If some older firmware really emitted millivolts on the same opcode, that legacy interpretation is no longer the primary path. The tradeoff is intentional because protocol correctness is more important than preserving an undocumented decoding heuristic.
