### PR TITLE
Serialize startup commands by response

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -1409,6 +1409,70 @@ class MeshCoreConnector extends ChangeNotifier {
     await sendFrame(buildGetBattAndStorageFrame());
   }
 
+  Future<bool> _sendFrameAndWaitForExpectedResponse(
+    Uint8List command, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final commandCode = command.isNotEmpty ? command[0] : -1;
+    final expectedCodes = expectedResponseCodesForCommand(commandCode);
+    if (expectedCodes.isEmpty) {
+      await sendFrame(command);
+      return true;
+    }
+
+    final completer = Completer<bool>();
+    late final StreamSubscription<Uint8List> subscription;
+    subscription = receivedFrames.listen((frame) {
+      if (frameMatchesCommandResponse(commandCode, frame) &&
+          !completer.isCompleted) {
+        completer.complete(true);
+      }
+    });
+
+    try {
+      await sendFrame(command);
+      final matched = await completer.future.timeout(
+        timeout,
+        onTimeout: () => false,
+      );
+      if (!matched) {
+        _appDebugLogService?.warn(
+          'Timed out waiting for response to command $commandCode',
+          tag: 'Protocol',
+        );
+      }
+      return matched;
+    } finally {
+      await subscription.cancel();
+    }
+  }
+
+  Future<void> _runStartupCommandSequence({required bool forceBattery}) async {
+    final commands = <Uint8List>[
+      buildDeviceQueryFrame(),
+      buildAppStartFrame(),
+      buildGetCustomVarsFrame(),
+      buildGetBattAndStorageFrame(),
+      buildGetAutoAddFlagsFrame(),
+    ];
+
+    for (final command in commands) {
+      if (!isConnected) {
+        return;
+      }
+      if (command.isNotEmpty &&
+          command[0] == cmdGetBattAndStorage &&
+          !forceBattery &&
+          _batteryRequested) {
+        continue;
+      }
+      await _sendFrameAndWaitForExpectedResponse(command);
+      if (command.isNotEmpty && command[0] == cmdGetBattAndStorage) {
+        _batteryRequested = true;
+      }
+    }
+  }
+
   void _startBatteryPolling() {
     _batteryPollTimer?.cancel();
     _batteryPollTimer = Timer.periodic(_batteryPollInterval, (timer) {
@@ -1439,11 +1503,7 @@ class MeshCoreConnector extends ChangeNotifier {
         _selfPublicKey == null) {
       _webInitialHandshakeRequestSent = true;
     }
-    await sendFrame(buildDeviceQueryFrame());
-    await sendFrame(buildAppStartFrame());
-    await requestBatteryStatus(force: true);
-    await sendFrame(buildGetCustomVarsFrame());
-    await sendFrame(buildGetAutoAddFlagsFrame());
+    await _runStartupCommandSequence(forceBattery: true);
 
     _scheduleSelfInfoRetry();
   }
@@ -1462,11 +1522,7 @@ class MeshCoreConnector extends ChangeNotifier {
         _selfPublicKey == null) {
       _webInitialHandshakeRequestSent = true;
     }
-    await sendFrame(buildDeviceQueryFrame());
-    await sendFrame(buildAppStartFrame());
-    await sendFrame(buildGetCustomVarsFrame());
-    await requestBatteryStatus();
-    await sendFrame(buildGetAutoAddFlagsFrame());
+    await _runStartupCommandSequence(forceBattery: false);
     _scheduleSelfInfoRetry();
   }
 

--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -253,6 +253,23 @@ const int pushCodeNewAdvert = 0x8A;
 const int pushCodeTelemetryResponse = 0x8B;
 const int pushCodeBinaryResponse = 0x8C;
 
+const Map<int, Set<int>> _commandResponseCodes = <int, Set<int>>{
+  cmdDeviceQuery: <int>{respCodeDeviceInfo},
+  cmdAppStart: <int>{respCodeSelfInfo},
+  cmdGetBattAndStorage: <int>{respCodeBattAndStorage},
+  cmdGetCustomVar: <int>{respCodeCustomVars},
+  cmdGetAutoAddConfig: <int>{respCodeAutoAddConfig},
+};
+
+Set<int> expectedResponseCodesForCommand(int commandCode) {
+  return _commandResponseCodes[commandCode] ?? const <int>{};
+}
+
+bool frameMatchesCommandResponse(int commandCode, Uint8List frame) {
+  if (frame.isEmpty) return false;
+  return expectedResponseCodesForCommand(commandCode).contains(frame[0]);
+}
+
 // Contact/advertisement types
 const int advTypeChat = 1;
 const int advTypeRepeater = 2;

--- a/test/connector/command_response_matching_test.dart
+++ b/test/connector/command_response_matching_test.dart
@@ -1,0 +1,64 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
+
+void main() {
+  group('expectedResponseCodesForCommand', () {
+    test('maps startup commands to documented responses', () {
+      expect(
+        expectedResponseCodesForCommand(cmdDeviceQuery),
+        equals(<int>{respCodeDeviceInfo}),
+      );
+      expect(
+        expectedResponseCodesForCommand(cmdAppStart),
+        equals(<int>{respCodeSelfInfo}),
+      );
+      expect(
+        expectedResponseCodesForCommand(cmdGetCustomVar),
+        equals(<int>{respCodeCustomVars}),
+      );
+      expect(
+        expectedResponseCodesForCommand(cmdGetBattAndStorage),
+        equals(<int>{respCodeBattAndStorage}),
+      );
+      expect(
+        expectedResponseCodesForCommand(cmdGetAutoAddConfig),
+        equals(<int>{respCodeAutoAddConfig}),
+      );
+    });
+
+    test('returns empty set for commands without an expected response map', () {
+      expect(expectedResponseCodesForCommand(cmdSendTxtMsg), isEmpty);
+    });
+  });
+
+  group('frameMatchesCommandResponse', () {
+    test('matches documented startup responses', () {
+      expect(
+        frameMatchesCommandResponse(
+          cmdDeviceQuery,
+          Uint8List.fromList(<int>[respCodeDeviceInfo, 0x01, 0x08, 0x04]),
+        ),
+        isTrue,
+      );
+      expect(
+        frameMatchesCommandResponse(
+          cmdAppStart,
+          Uint8List.fromList(<int>[respCodeSelfInfo, 0x00]),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects non-matching responses', () {
+      expect(
+        frameMatchesCommandResponse(
+          cmdAppStart,
+          Uint8List.fromList(<int>[respCodeDeviceInfo, 0x00]),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The firmware docs require sending one command at a time and waiting for the matching response before issuing the next command. The app's startup handshake sent several requests back-to-back during connection and refresh flows. That can race responses, violate documented sequencing expectations, and make startup behavior depend on firmware tolerance for concurrent outstanding commands.

## Fix

Introduce documented command-response matching for the startup sequence and serialize the initial handshake commands:
- device query
- app start
- custom vars
- battery/status
- auto-add config

Add a small helper that sends a command, waits for the expected response type, and times out cleanly before continuing.

Add tests that verify the documented response mapping and frame-to-command matching behavior.

## Why this fixes it

Startup now follows the sequencing model described by the firmware docs. Each request is allowed to complete before the next one is sent, which removes command overlap during the initial handshake and makes the app's connection flow conform to the documented command queue requirement.

## Tradeoffs

This makes startup slightly more serialized and can increase connection latency on slow links because commands are no longer pipelined. That is the correct tradeoff for the handshake path because reliability and protocol conformance matter more than shaving a small amount of startup time.
