### PR TITLE
Make unread badge max out at 9999+ instead of 99+

### DIFF
--- a/lib/widgets/unread_badge.dart
+++ b/lib/widgets/unread_badge.dart
@@ -7,7 +7,7 @@ class UnreadBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final display = count > 99 ? '99+' : count.toString();
+    final display = count > 9999 ? '9999+' : count.toString();
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(


### PR DESCRIPTION
Tiny change. Public chat on large networks can often produce couple of hundreds messages per day. So '99+' is not so informative.