### PR TITLE
Add additional device name prefixes to MeshCoreUuids

### DIFF
--- a/lib/connector/meshcore_uuids.dart
+++ b/lib/connector/meshcore_uuids.dart
@@ -7,6 +7,8 @@ class MeshCoreUuids {
     "MeshCore-",
     "Whisper-",
     "WisCore-",
+    "Seeed",
+    "Lilygo",
     "HT-",
   ];
 }


### PR DESCRIPTION
This pull request makes a minor update to the `MeshCoreUuids` class by adding two new device prefixes to the list of recognized device names.

- Added `"Seeed"` and `"Lilygo"` to the list of device name prefixes in `MeshCoreUuids` to support additional hardware.