### PR TITLE
Add Android-level localization support with Ukrainian locale

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
     <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
 
     <application
-        android:label="meshcore_open"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <service

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MeshCore Open</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MeshCore Open</string>
+</resources>


### PR DESCRIPTION
## Summary
- Add `values/strings.xml` with base `app_name` string resource
- Add `values-uk/strings.xml` for Ukrainian locale
- Replace hardcoded `android:label="meshcore_open"` in `AndroidManifest.xml` with `@string/app_name` resource reference

This enables proper Android-level localization for the app label (shown in launcher, recent apps, etc.) and adds Ukrainian as the first locale. Other languages can be added by creating corresponding `values-<locale>/strings.xml` files.

## Test plan
- [x] Built debug APK successfully
- [x] Verified `application-label-uk:'MeshCore Open'` present in APK via `aapt dump badging`
- [x] Installed and tested on Pixel 9 Pro XL

🤖 Generated with [Claude Code](https://claude.com/claude-code)