### PR TITLE
Add LowMesh prefix and explain how to add more

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## BLE Frames & Protocol Notes
 - Nordic UART Service (NUS) UUIDs: Service `6e400001-b5a3-f393-e0a9-e50e24dcca9e`, RX `6e400002-b5a3-f393-e0a9-e50e24dcca9e`, TX `6e400003-b5a3-f393-e0a9-e50e24dcca9e`.
-- Discovery: scans for device name prefix `MeshCore-` and filters by `platformName`/`advertisementData.advName`.
+- Discovery: scans for device names matching known prefixes and filters by `platformName`/`advertisementData.advName`.
 - Frames are capped at `maxFrameSize = 172` bytes; byte 0 is the command/response/push code. I/O is `MeshCoreConnector.sendFrame` and `MeshCoreConnector.receivedFrames`.
 - Command codes (to device): `cmdAppStart`=1, `cmdSendTxtMsg`=2, `cmdSendChannelTxtMsg`=3, `cmdGetContacts`=4, `cmdGetDeviceTime`=5, `cmdSetDeviceTime`=6, `cmdSendSelfAdvert`=7, `cmdSetAdvertName`=8, `cmdAddUpdateContact`=9, `cmdSyncNextMessage`=10, `cmdSetRadioParams`=11, `cmdSetRadioTxPower`=12, `cmdResetPath`=13, `cmdSetAdvertLatLon`=14, `cmdRemoveContact`=15, `cmdShareContact`=16, `cmdExportContact`=17, `cmdImportContact`=18, `cmdReboot`=19, `cmdSendLogin`=26, `cmdGetChannel`=31, `cmdSetChannel`=32, `cmdGetRadioSettings`=57.
 - Response codes (from device): `respCodeOk`=0, `respCodeErr`=1, `respCodeContactsStart`=2, `respCodeContact`=3, `respCodeEndOfContacts`=4, `respCodeSelfInfo`=5, `respCodeSent`=6, `respCodeContactMsgRecv`=7, `respCodeChannelMsgRecv`=8, `respCodeCurrTime`=9, `respCodeNoMoreMessages`=10, `respCodeContactMsgRecvV3`=16, `respCodeChannelMsgRecvV3`=17, `respCodeChannelInfo`=18, `respCodeRadioSettings`=25.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ lib/
 - **TX Characteristic**: `6e400003-b5a3-f393-e0a9-e50e24dcca9e` (Notify from device)
 
 ### Device Discovery
-- Scans for devices with name prefix `MeshCore-`
+- Scans for devices with known name prefixes
 - Filters by `platformName` or `advertisementData.advName`
 
 ### Connection States

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ lib/
 ├── main.dart                    # App entry point
 ├── connector/
 │   ├── meshcore_connector.dart  # BLE communication & state management
-│   └── meshcore_protocol.dart   # Protocol definitions & frame parsing
+│   ├── meshcore_protocol.dart   # Protocol definitions & frame parsing
+│   └── meshcore_uuids.dart      # Device names and IDs (add prefixes here!)
 ├── screens/
 │   ├── scanner_screen.dart      # Device scanning (home screen)
 │   ├── contacts_screen.dart     # Contact list
@@ -184,7 +185,15 @@ lib/
 
 ### Device Discovery
 
-Devices are discovered by scanning for BLE advertisements with the name prefix `MeshCore-`
+Devices are discovered by scanning for BLE advertisements with known MeshCore device name prefixes. These are currently:
+    - `MeshCore-`
+    - `Whisper-`
+    - `WisCore-`
+    - `HT-`
+    - `LowMesh_MC_`
+
+New device prefixes can be added in `lib/connector/meshcore_uuids.dart`.
+
 
 ### Message Format
 

--- a/docs/BLE_PROTOCOL.md
+++ b/docs/BLE_PROTOCOL.md
@@ -21,7 +21,12 @@ The MeshCore BLE protocol implements a binary frame-based communication system u
 
 ### Connection Flow
 
-1. **Scan** for devices with name prefix `MeshCore-`
+1. **Scan** for devices with known name prefixes (defined in `MeshCoreUuids.deviceNamePrefixes`):
+    - `MeshCore-`
+    - `Whisper-`
+    - `WisCore-`
+    - `HT-`
+    - `LowMesh_MC_`
 2. **Connect** with 15-second timeout
 3. **Request MTU** of 185 bytes (falls back to default if unsupported)
 4. **Discover services** and locate NUS characteristics

--- a/documentation/ble-protocol.md
+++ b/documentation/ble-protocol.md
@@ -49,7 +49,12 @@ enum MeshCoreConnectionState {
 
 ## BLE Connection Lifecycle
 
-1. **Scan** with keyword filters `["MeshCore-", "Whisper-"]`
+1. **Scan** with known name prefixes (defined in `MeshCoreUuids.deviceNamePrefixes`):
+    - `MeshCore-`
+    - `Whisper-`
+    - `WisCore-`
+    - `HT-`
+    - `LowMesh_MC_`
 2. **Connect** with 15-second timeout
 3. **Request MTU** 185 bytes (non-web only)
 4. **Discover services** and locate NUS

--- a/lib/connector/meshcore_uuids.dart
+++ b/lib/connector/meshcore_uuids.dart
@@ -8,5 +8,6 @@ class MeshCoreUuids {
     "Whisper-",
     "WisCore-",
     "HT-",
+    "LowMesh_MC_",
   ];
 }


### PR DESCRIPTION
This adds the Bluetooth name prefix used by the LowMesh Pocket-Ranger (and possibly other LowMesh brand devices) when running LowMesh's flavor of MeshCore 1.14 as obtained from [the LowMesh flasher](https://lowmesh.com/flasher).

It also updates various places in the documentation that referenced only one or a couple prefixes, and documents where the real list of prefixes lives and how to add more.

I tested this on Android, and Alpha 7 couldn't see the device whereas this build (eventually) could. (With the Windows build I could see the device whether the name prefix was in the list or not, but could never connect to it.)

This hopefully won't conflict with #321, since the added lines are in slightly different places.