### PR TITLE
Preserve Coordinates with contact.copyWith() function

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -3913,11 +3913,14 @@ class MeshCoreConnector extends ChangeNotifier {
           tag: 'Connector',
         );
 
-        // CRITICAL: Preserve user's path override when contact is refreshed from device
+        // Preserve user-selected path settings and previously known GPS when
+        // refreshed frames omit coordinates (lat/lon encoded as 0,0).
         _contacts[existingIndex] = contact.copyWith(
           lastMessageAt: mergedLastMessageAt,
           pathOverride: existing.pathOverride, // Preserve user's path choice
           pathOverrideBytes: existing.pathOverrideBytes,
+          latitude: contact.latitude ?? existing.latitude,
+          longitude: contact.longitude ?? existing.longitude,
         );
 
         appLogger.info(


### PR DESCRIPTION
Previously, the merge only preserved path override fields and could overwrite existing GPS with null when the incoming frame had 0,0 coordinates. Now it also preserves prior coordinates when the incoming update omits location.
Should address Issue #336.