### PR TITLE
add auto clock synchronization setting after repeater login

### DIFF
--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingHidePin": "Скриване на PIN кода",
   "scanner_linuxPairingShowPin": "Покажи PIN",
   "repeater_cliQuickClockSync": "Синхронизация на часовника",
-  "repeater_cliQuickDiscovery": "Открий Съседи"
+  "repeater_cliQuickDiscovery": "Открий Съседи",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Автоматично изпращайте съобщение \"синхронизиране на часовника\" след успешно влизане.",
+  "repeater_clockSyncAfterLogin": "Синхронизиране на часовника след влизане"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2089,5 +2089,13 @@
   "scanner_linuxPairingPinTitle": "Bluetooth-Paarungs-PIN",
   "scanner_linuxPairingPinPrompt": "Geben Sie die PIN für {deviceName} ein (leer lassen, falls keine).",
   "repeater_cliQuickClockSync": "Uhr Synchronisieren",
-  "repeater_cliQuickDiscovery": "Entdecke Nachbarn"
+  "repeater_cliQuickDiscovery": "Entdecke Nachbarn",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "Uhrzeit-Synchronisation nach dem Anmelden",
+  "repeater_clockSyncAfterLoginSubtitle": "Automatisch \"Uhrzeit-Synchronisierung\" nach erfolgreicher Anmeldung senden."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1116,6 +1116,14 @@
   "repeater_neighborsSubtitle": "View zero hop neighbors.",
   "repeater_settings": "Settings",
   "repeater_settingsSubtitle": "Configure repeater parameters",
+  "repeater_clockSyncAfterLogin": "Clock sync after login",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Automatically send \"clock sync\" after a successful login",
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
   "repeater_statusTitle": "Repeater Status",
   "repeater_routingMode": "Routing mode",
   "repeater_autoUseSavedPath": "Auto (use saved path)",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2089,5 +2089,13 @@
   "translation_translationOptions": "Opciones de traducción",
   "translation_systemLanguage": "Idioma del sistema",
   "repeater_cliQuickDiscovery": "Descubrir Vecinos",
-  "repeater_cliQuickClockSync": "Sincronización del reloj"
+  "repeater_cliQuickClockSync": "Sincronización del reloj",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Enviar automáticamente la función de \"sincronización de reloj\" después de un inicio de sesión exitoso.",
+  "repeater_clockSyncAfterLogin": "Sincronización del reloj después de iniciar sesión"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinPrompt": "Entrez le code PIN pour {deviceName} (laissez vide si nécessaire).",
   "scanner_linuxPairingShowPin": "Afficher le code PIN",
   "repeater_cliQuickClockSync": "Synchronisation de l'horloge",
-  "repeater_cliQuickDiscovery": "Découvrir les voisins"
+  "repeater_cliQuickDiscovery": "Découvrir les voisins",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Envoyer automatiquement une notification \"synchronisation de l'heure\" après une connexion réussie.",
+  "repeater_clockSyncAfterLogin": "Synchronisation de l'horloge après la connexion"
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -2081,7 +2081,7 @@
     }
   },
   "scanner_linuxPairingShowPin": "Megjelenítse a PIN-kódot",
-  "scanner_linuxPairingPinPrompt": "Adja meg a PIN kódot a {deviceName} számára (hagyja üresen, ha nincs).",
+  "scanner_linuxPairingPinPrompt": "Adja meg a(z) {deviceName} PIN-kódját (hagyja üresen, ha nincs).",
   "scanner_linuxPairingHidePin": "Rejtse el a PIN-kódot",
   "scanner_linuxPairingPinTitle": "Bluetooth párosítási PIN",
   "@translation_translateTo": {
@@ -2098,7 +2098,14 @@
   "translation_translateTo": "Fordítás {language}-ra",
   "translation_translationOptions": "Fordítási lehetőségek",
   "translation_systemLanguage": "Rendszer nyelvé",
- "scanner_linuxPairingPinPrompt": "Adja meg a(z) {deviceName} PIN-kódját (hagyja üresen, ha nincs).",
   "repeater_cliQuickClockSync": "Óra szinkronizálás",
-  "repeater_cliQuickDiscovery": "Fedezd fel a szomszédokat"
+  "repeater_cliQuickDiscovery": "Fedezd fel a szomszédokat",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Automatikusan küldje el a \"óra szinkronizálás\" üzenetet a sikeres bejelentkezés után.",
+  "repeater_clockSyncAfterLogin": "Óra szinkronizálás bejelentkezés után"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinTitle": "PIN per l'accoppiamento Bluetooth",
   "scanner_linuxPairingHidePin": "Nascondi il PIN",
   "repeater_cliQuickClockSync": "Sincronizzazione dell'orologio",
-  "repeater_cliQuickDiscovery": "Scopri i Vicini"
+  "repeater_cliQuickDiscovery": "Scopri i Vicini",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Invia automaticamente il comando \"sincronizzazione dell'orologio\" dopo un login riuscito.",
+  "repeater_clockSyncAfterLogin": "Sincronizzazione dell'orologio dopo il login"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2099,5 +2099,13 @@
   "scanner_linuxPairingPinTitle": "Bluetooth ペアリング PIN",
   "scanner_linuxPairingPinPrompt": "{deviceName}のPINを入力してください（なしの場合は空欄のまま）。",
   "repeater_cliQuickClockSync": "クロック同期",
-  "repeater_cliQuickDiscovery": "近隣を発見する"
+  "repeater_cliQuickDiscovery": "近隣を発見する",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "ログイン後、時計の時刻を同期する",
+  "repeater_clockSyncAfterLoginSubtitle": "ログインが成功した場合、自動的に「時刻同期」を送信する。"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -2099,5 +2099,13 @@
   "translation_translationOptions": "번역 옵션",
   "translation_systemLanguage": "시스템 언어",
   "repeater_cliQuickClockSync": "시계 동기화",
-  "repeater_cliQuickDiscovery": "이웃 발견하기"
+  "repeater_cliQuickDiscovery": "이웃 발견하기",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "로그인 후 시계 동기화",
+  "repeater_clockSyncAfterLoginSubtitle": "성공적인 로그인 후, 자동으로 \"시간 동기화\"를 전송합니다."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3675,6 +3675,18 @@ abstract class AppLocalizations {
   /// **'Configure repeater parameters'**
   String get repeater_settingsSubtitle;
 
+  /// Repeater setting: auto sync device clock after successful login
+  ///
+  /// In en, this message translates to:
+  /// **'Clock sync after login'**
+  String get repeater_clockSyncAfterLogin;
+
+  /// Repeater setting subtitle: describes the clock sync after login behavior
+  ///
+  /// In en, this message translates to:
+  /// **'Automatically send \"clock sync\" after a successful login'**
+  String get repeater_clockSyncAfterLoginSubtitle;
+
   /// No description provided for @repeater_statusTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2057,6 +2057,14 @@ class AppLocalizationsBg extends AppLocalizations {
       'Конфигурирайте параметрите на репитера';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Синхронизиране на часовника след влизане';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Автоматично изпращайте съобщение \"синхронизиране на часовника\" след успешно влизане.';
+
+  @override
   String get repeater_statusTitle => 'Статус на повтарянето';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2053,6 +2053,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Repeater-parameter konfigurieren';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Uhrzeit-Synchronisation nach dem Anmelden';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automatisch \"Uhrzeit-Synchronisierung\" nach erfolgreicher Anmeldung senden.';
+
+  @override
   String get repeater_statusTitle => 'Repeaterstatus';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2015,6 +2015,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Configure repeater parameters';
 
   @override
+  String get repeater_clockSyncAfterLogin => 'Clock sync after login';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automatically send \"clock sync\" after a successful login';
+
+  @override
   String get repeater_statusTitle => 'Repeater Status';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2051,6 +2051,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Configurar parámetros del repetidor';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Sincronización del reloj después de iniciar sesión';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Enviar automáticamente la función de \"sincronización de reloj\" después de un inicio de sesión exitoso.';
+
+  @override
   String get repeater_statusTitle => 'Estado del Repetidor';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2063,6 +2063,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Configurer les paramètres du répéteur';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Synchronisation de l\'horloge après la connexion';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Envoyer automatiquement une notification \"synchronisation de l\'heure\" après une connexion réussie.';
+
+  @override
   String get repeater_statusTitle => 'État du répéteur';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2067,6 +2067,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Állítsa be a repeater paramétereket';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Óra szinkronizálás bejelentkezés után';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automatikusan küldje el a \"óra szinkronizálás\" üzenetet a sikeres bejelentkezés után.';
+
+  @override
   String get repeater_statusTitle => 'Adatkapcsolódás állapot';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2054,6 +2054,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Configura i parametri del ripetitore';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Sincronizzazione dell\'orologio dopo il login';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Invia automaticamente il comando \"sincronizzazione dell\'orologio\" dopo un login riuscito.';
+
+  @override
   String get repeater_statusTitle => 'Stato del Ripetitore';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1966,6 +1966,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get repeater_settingsSubtitle => 'リピーターのパラメータを設定する';
 
   @override
+  String get repeater_clockSyncAfterLogin => 'ログイン後、時計の時刻を同期する';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'ログインが成功した場合、自動的に「時刻同期」を送信する。';
+
+  @override
   String get repeater_statusTitle => '再送ステータス';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1963,6 +1963,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get repeater_settingsSubtitle => '리피터 파라미터 설정';
 
   @override
+  String get repeater_clockSyncAfterLogin => '로그인 후 시계 동기화';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      '성공적인 로그인 후, 자동으로 \"시간 동기화\"를 전송합니다.';
+
+  @override
   String get repeater_statusTitle => '반복 장치 상태';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2039,6 +2039,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Configureer repeaterparameters';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Na het inloggen, klok synchroniseren';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automatisch een \"klok synchroniseren\" bericht versturen na een succesvolle inlog.';
+
+  @override
   String get repeater_statusTitle => 'Status repeater';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2067,6 +2067,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Skonfiguruj parametry przekaźnika';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Synchronizacja zegara po zalogowaniu';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automatycznie wysyłaj powiadomienie \"synchronizacja zegara\" po pomyślnym zalogowaniu.';
+
+  @override
   String get repeater_statusTitle => 'Status przekaźnika';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2051,6 +2051,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Configurar parâmetros do repetidor';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Sincronização do relógio após o login';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Enviar automaticamente a sincronização do \"relógio\" após um login bem-sucedido.';
+
+  @override
   String get repeater_statusTitle => 'Status do Repetidor';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2055,6 +2055,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Настройка параметров репитера';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Синхронизация часов после входа в систему';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Автоматически отправлять сообщение \"синхронизация времени\" после успешной авторизации.';
+
+  @override
   String get repeater_statusTitle => 'Статус репитера';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2040,6 +2040,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Konfigurujte parametre opakovača';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Synchronizácia hodiniek po prihlávení';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automaticky posielajte notifikáciu \"synchronizácia času\" po úspešnom prihládení.';
+
+  @override
   String get repeater_statusTitle => 'Status opakého zboru';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2039,6 +2039,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Konfigurirajte parametre ponovitelja';
 
   @override
+  String get repeater_clockSyncAfterLogin => 'Sinhronizacija ure po prijavi';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Samodejno po uspešnem vstopu pošljite obvestilo o sinhronizaciji časa.';
+
+  @override
   String get repeater_statusTitle => 'Status ponovitelja';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2026,6 +2026,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Konfigurera återspolarparametrar';
 
   @override
+  String get repeater_clockSyncAfterLogin =>
+      'Synkronisera klockan efter inloggning';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Automatiskt skicka \"klocksynkronisering\" efter en lyckad inloggning.';
+
+  @override
   String get repeater_statusTitle => 'Återspelsstatus';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2051,6 +2051,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get repeater_settingsSubtitle => 'Налаштувати параметри ретранслятора';
 
   @override
+  String get repeater_clockSyncAfterLogin => 'Синхронізація годин після входу';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle =>
+      'Автоматично надсилати повідомлення \"синхронізація годин\" після успішного входу.';
+
+  @override
   String get repeater_statusTitle => 'Статус ретранслятора';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1924,6 +1924,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get repeater_settingsSubtitle => '配置转发节点参数';
 
   @override
+  String get repeater_clockSyncAfterLogin => '登录后，自动同步时钟';
+
+  @override
+  String get repeater_clockSyncAfterLoginSubtitle => '在成功登录后，自动发送“时钟同步”指令。';
+
+  @override
   String get repeater_statusTitle => '转发节点状态';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinPrompt": "Voer PIN in voor {deviceName} (laat leeg als er geen is).",
   "scanner_linuxPairingPinTitle": "Bluetooth‑koppelings‑PIN",
   "repeater_cliQuickDiscovery": "Ontdek Buren",
-  "repeater_cliQuickClockSync": "Kloksynchronisatie"
+  "repeater_cliQuickClockSync": "Kloksynchronisatie",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Automatisch een \"klok synchroniseren\" bericht versturen na een succesvolle inlog.",
+  "repeater_clockSyncAfterLogin": "Na het inloggen, klok synchroniseren"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -2099,5 +2099,13 @@
   "scanner_linuxPairingPinPrompt": "Wprowadź kod PIN dla {deviceName} (pozostaw puste, jeśli brak).",
   "scanner_linuxPairingPinTitle": "Kod PIN parowania Bluetooth",
   "repeater_cliQuickClockSync": "Synchronizacja zegara",
-  "repeater_cliQuickDiscovery": "Odkryj Sąsiadów"
+  "repeater_cliQuickDiscovery": "Odkryj Sąsiadów",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "Synchronizacja zegara po zalogowaniu",
+  "repeater_clockSyncAfterLoginSubtitle": "Automatycznie wysyłaj powiadomienie \"synchronizacja zegara\" po pomyślnym zalogowaniu."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinPrompt": "Insira o PIN para {deviceName} (deixe em branco se não houver).",
   "scanner_linuxPairingPinTitle": "PIN de emparelhamento Bluetooth",
   "repeater_cliQuickClockSync": "Sincronização do Relógio",
-  "repeater_cliQuickDiscovery": "Descobrir Vizinhos"
+  "repeater_cliQuickDiscovery": "Descobrir Vizinhos",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Enviar automaticamente a sincronização do \"relógio\" após um login bem-sucedido.",
+  "repeater_clockSyncAfterLogin": "Sincronização do relógio após o login"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1301,5 +1301,13 @@
   "scanner_linuxPairingHidePin": "Скрыть PIN",
   "scanner_linuxPairingPinTitle": "PIN‑код сопряжения Bluetooth",
   "repeater_cliQuickDiscovery": "Обнаружить Соседей",
-  "repeater_cliQuickClockSync": "Синхронизация часов"
+  "repeater_cliQuickClockSync": "Синхронизация часов",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "Синхронизация часов после входа в систему",
+  "repeater_clockSyncAfterLoginSubtitle": "Автоматически отправлять сообщение \"синхронизация времени\" после успешной авторизации."
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -2061,5 +2061,13 @@
   "translation_translationOptions": "Možnosti prekladania",
   "translation_systemLanguage": "Jazyk systému",
   "repeater_cliQuickClockSync": "Synchronizácia hodin",
-  "repeater_cliQuickDiscovery": "Objaviť susedov"
+  "repeater_cliQuickDiscovery": "Objaviť susedov",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "Synchronizácia hodiniek po prihlávení",
+  "repeater_clockSyncAfterLoginSubtitle": "Automaticky posielajte notifikáciu \"synchronizácia času\" po úspešnom prihládení."
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinPrompt": "Vnesite PIN za {deviceName} (pustite prazno, če ga ni).",
   "scanner_linuxPairingPinTitle": "Bluetooth PIN za seznanjanje",
   "repeater_cliQuickDiscovery": "Odkrijte sosede",
-  "repeater_cliQuickClockSync": "Usklajevanje ure"
+  "repeater_cliQuickClockSync": "Usklajevanje ure",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Samodejno po uspešnem vstopu pošljite obvestilo o sinhronizaciji časa.",
+  "repeater_clockSyncAfterLogin": "Sinhronizacija ure po prijavi"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinPrompt": "Ange PIN för {deviceName} (lämna tomt om ingen).",
   "scanner_linuxPairingHidePin": "Dölj PIN",
   "repeater_cliQuickDiscovery": "Upptäck grannar",
-  "repeater_cliQuickClockSync": "Synkronisera klocka"
+  "repeater_cliQuickClockSync": "Synkronisera klocka",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Automatiskt skicka \"klocksynkronisering\" efter en lyckad inloggning.",
+  "repeater_clockSyncAfterLogin": "Synkronisera klockan efter inloggning"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -2061,5 +2061,13 @@
   "scanner_linuxPairingPinPrompt": "Введіть PIN для {deviceName} (залиште порожнім, якщо його немає).",
   "scanner_linuxPairingHidePin": "Приховати PIN",
   "repeater_cliQuickClockSync": "Синхронізація годинника",
-  "repeater_cliQuickDiscovery": "Відкрити сусідів"
+  "repeater_cliQuickDiscovery": "Відкрити сусідів",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLoginSubtitle": "Автоматично надсилати повідомлення \"синхронізація годин\" після успішного входу.",
+  "repeater_clockSyncAfterLogin": "Синхронізація годин після входу"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2066,5 +2066,13 @@
   "translation_translationOptions": "翻译选项",
   "translation_systemLanguage": "系统语言",
   "repeater_cliQuickDiscovery": "发现邻居",
-  "repeater_cliQuickClockSync": "同步时钟"
+  "repeater_cliQuickClockSync": "同步时钟",
+  "@repeater_clockSyncAfterLogin": {
+    "description": "Repeater setting: auto sync device clock after successful login"
+  },
+  "@repeater_clockSyncAfterLoginSubtitle": {
+    "description": "Repeater setting subtitle: describes the clock sync after login behavior"
+  },
+  "repeater_clockSyncAfterLogin": "登录后，自动同步时钟",
+  "repeater_clockSyncAfterLoginSubtitle": "在成功登录后，自动发送“时钟同步”指令。"
 }

--- a/lib/screens/repeater_settings_screen.dart
+++ b/lib/screens/repeater_settings_screen.dart
@@ -8,6 +8,7 @@ import '../connector/meshcore_connector.dart';
 import '../connector/meshcore_protocol.dart';
 import '../services/app_debug_log_service.dart';
 import '../services/repeater_command_service.dart';
+import '../services/storage_service.dart';
 import '../widgets/path_management_dialog.dart';
 
 class RepeaterSettingsScreen extends StatefulWidget {
@@ -25,6 +26,8 @@ class RepeaterSettingsScreen extends StatefulWidget {
 }
 
 class _RepeaterSettingsScreenState extends State<RepeaterSettingsScreen> {
+  final StorageService _storage = StorageService();
+
   bool _isLoading = false;
   bool _hasChanges = false;
   bool _refreshingBasic = false;
@@ -59,6 +62,7 @@ class _RepeaterSettingsScreenState extends State<RepeaterSettingsScreen> {
   bool _repeatEnabled = true;
   bool _allowReadOnly = true;
   bool _privacyMode = false;
+  bool _autoClockSyncAfterLogin = false;
 
   // Advertisement settings
   bool _advertEnable = true;
@@ -565,6 +569,15 @@ class _RepeaterSettingsScreenState extends State<RepeaterSettingsScreen> {
         _latController.text = widget.repeater.latitude?.toString() ?? '';
         _lonController.text = widget.repeater.longitude?.toString() ?? '';
       }
+    });
+
+    final autoClockSync = await _storage
+        .getRepeaterAutoClockSyncAfterLoginEnabled(
+          widget.repeater.publicKeyHex,
+        );
+    if (!mounted) return;
+    setState(() {
+      _autoClockSyncAfterLogin = autoClockSync;
     });
   }
 
@@ -1138,6 +1151,21 @@ class _RepeaterSettingsScreenState extends State<RepeaterSettingsScreen> {
               },
               onRefresh: _refreshAllowReadOnly,
               refreshTooltip: l10n.repeater_refreshGuestAccess,
+            ),
+            SwitchListTile(
+              title: Text(l10n.repeater_clockSyncAfterLogin),
+              subtitle: Text(l10n.repeater_clockSyncAfterLoginSubtitle),
+              value: _autoClockSyncAfterLogin,
+              onChanged: (value) async {
+                setState(() {
+                  _autoClockSyncAfterLogin = value;
+                });
+                await _storage.setRepeaterAutoClockSyncAfterLoginEnabled(
+                  widget.repeater.publicKeyHex,
+                  value,
+                );
+              },
+              contentPadding: EdgeInsets.zero,
             ),
             // Privacy mode - hidden until fully implemented
             // _buildFeatureToggleRow(

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -7,7 +7,41 @@ class StorageService {
   static const String _pathHistoryPrefix = 'path_history_';
   static const String _pendingMessagesKey = 'pending_messages';
   static const String _repeaterPasswordsKey = 'repeater_passwords';
+  static const String _repeaterAutoClockSyncAfterLoginKey =
+      'repeater_auto_clock_sync_after_login';
   static const String _deliveryObservationsKey = 'delivery_observations';
+
+  Future<Map<String, bool>> _loadRepeaterAutoClockSyncAfterLogin() async {
+    final prefs = PrefsManager.instance;
+    final jsonStr = prefs.getString(_repeaterAutoClockSyncAfterLoginKey);
+
+    if (jsonStr == null) return {};
+
+    try {
+      final json = jsonDecode(jsonStr) as Map<String, dynamic>;
+      return json.map((key, value) => MapEntry(key, value == true));
+    } catch (e) {
+      return {};
+    }
+  }
+
+  Future<bool> getRepeaterAutoClockSyncAfterLoginEnabled(
+    String repeaterPubKeyHex,
+  ) async {
+    final settings = await _loadRepeaterAutoClockSyncAfterLogin();
+    return settings[repeaterPubKeyHex] ?? false;
+  }
+
+  Future<void> setRepeaterAutoClockSyncAfterLoginEnabled(
+    String repeaterPubKeyHex,
+    bool enabled,
+  ) async {
+    final prefs = PrefsManager.instance;
+    final settings = await _loadRepeaterAutoClockSyncAfterLogin();
+    settings[repeaterPubKeyHex] = enabled;
+    final jsonStr = jsonEncode(settings);
+    await prefs.setString(_repeaterAutoClockSyncAfterLoginKey, jsonStr);
+  }
 
   Future<void> savePathHistory(
     String contactPubKeyHex,

--- a/lib/widgets/repeater_login_dialog.dart
+++ b/lib/widgets/repeater_login_dialog.dart
@@ -187,6 +187,29 @@ class _RepeaterLoginDialogState extends State<RepeaterLoginDialog> {
         await _storage.removeRepeaterPassword(widget.repeater.publicKeyHex);
       }
 
+      final autoClockSync = await _storage
+          .getRepeaterAutoClockSyncAfterLoginEnabled(
+            widget.repeater.publicKeyHex,
+          );
+      if (autoClockSync) {
+        try {
+          final timestampSeconds =
+              DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          await _connector.sendFrame(
+            buildSendCliCommandFrame(
+              repeater.publicKey,
+              'clock sync',
+              timestampSeconds: timestampSeconds,
+            ),
+          );
+        } catch (e) {
+          appLogger.warn(
+            'Auto clock sync failed for ${repeater.name}: $e',
+            tag: 'RepeaterLogin',
+          );
+        }
+      }
+
       if (mounted) {
         Navigator.pop(context, password);
         Future.microtask(() => widget.onLogin(password));


### PR DESCRIPTION
Introduced a new setting for automatic clock synchronization after a successful repeater login. Added localization support for the new feature in multiple languages (Bulgarian, German, English, Spanish, French, Hungarian, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Russian, Slovak, Slovenian, Swedish, Ukrainian, Chinese). Implemented storage service methods to manage the new setting. Updated the repeater settings screen to include a toggle for the new feature. Enhanced the repeater login dialog to trigger clock synchronization automatically if the setting is enabled. [Feature Request #349](https://github.com/zjs81/meshcore-open/issues/349)


https://github.com/user-attachments/assets/b575dc54-a8f8-4a13-9f65-385c8d397013

