### PR TITLE
Remove colorisation of repeaters with same prefix as red

### DIFF
--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_multiAck": "Мулти-потвърди: {value}",
   "settings_telemetryModeUpdated": "Режим на телеметрията е обновен",
-  "map_showOverlaps": "Покриване на ключа на повтаряча",
   "map_runTraceWithReturnPath": "Върни се по същия път.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1970,7 +1970,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Telemetriemodus aktualisiert",
   "settings_multiAck": "Mehrfach-Bestätigungen: {value}",
-  "map_showOverlaps": "Überlappungen der Repeater-Taste",
   "map_runTraceWithReturnPath": "Auf dem gleichen Pfad zurückkehren.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -892,7 +892,6 @@
   "map_chatNodes": "Chat Nodes",
   "map_repeaters": "Repeaters",
   "map_otherNodes": "Other Nodes",
-  "map_showOverlaps": "Repeater Key Overlaps",
   "map_keyPrefix": "Key Prefix",
   "map_filterByKeyPrefix": "Filter by key prefix",
   "map_publicKeyPrefix": "Public key prefix",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1970,7 +1970,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Modo de telemetría actualizado",
   "settings_multiAck": "Multi-ACKs: {value}",
-  "map_showOverlaps": "Superposiciones de tecla repetidora",
   "map_runTraceWithReturnPath": "Volver atrás por el mismo camino.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_multiAck": "Multi-ACKs : {value}",
   "settings_telemetryModeUpdated": "Le mode télémétrie a été mis à jour",
-  "map_showOverlaps": "Chevauchement de la touche répétitive",
   "map_runTraceWithReturnPath": "Revenir sur le même chemin.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -2043,7 +2043,6 @@
   "contact_teleLocSubtitle": "Engedje meg a helyadatok megosztását",
   "contact_teleEnv": "Adatkapcsolati környezet",
   "contact_teleEnvSubtitle": "Engedje meg az érzékelő adatok megosztását",
-  "map_showOverlaps": "Az ismétlő kulcsok ütköznek",
   "map_runTraceWithReturnPath": "Visszaforduljon az eredeti úton.",
   "@translation_downloadFailed": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Modalità telemetria aggiornata",
   "settings_multiAck": "Multi-ACKs: {value}",
-  "map_showOverlaps": "Sovrapposizioni della chiave ripetitore",
   "map_runTraceWithReturnPath": "Tornare indietro sullo stesso percorso",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2043,7 +2043,6 @@
   "contact_teleLocSubtitle": "位置情報共有を許可する",
   "contact_teleEnv": "テレメトリ環境",
   "contact_teleEnvSubtitle": "環境センサーのデータを共有することを許可する",
-  "map_showOverlaps": "リピーターキーの重複",
   "map_runTraceWithReturnPath": "元の経路に戻る。",
   "@translation_downloadFailed": {
     "placeholders": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -2043,7 +2043,6 @@
   "contact_teleLocSubtitle": "위치 정보 공유 허용",
   "contact_teleEnv": "텔레메트리 환경",
   "contact_teleEnvSubtitle": "환경 센서 데이터를 공유하도록 허용",
-  "map_showOverlaps": "반복 키 중복",
   "map_runTraceWithReturnPath": "원래 경로로 돌아가세요.",
   "@translation_downloadFailed": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3064,12 +3064,6 @@ abstract class AppLocalizations {
   /// **'Other Nodes'**
   String get map_otherNodes;
 
-  /// No description provided for @map_showOverlaps.
-  ///
-  /// In en, this message translates to:
-  /// **'Repeater Key Overlaps'**
-  String get map_showOverlaps;
-
   /// No description provided for @map_keyPrefix.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1693,9 +1693,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get map_otherNodes => 'Други възли';
 
   @override
-  String get map_showOverlaps => 'Покриване на ключа на повтаряча';
-
-  @override
   String get map_keyPrefix => 'Префикс на ключа';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1690,9 +1690,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get map_otherNodes => 'Andere Knoten';
 
   @override
-  String get map_showOverlaps => 'Überlappungen der Repeater-Taste';
-
-  @override
   String get map_keyPrefix => 'Schlüsselpräfix';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1660,9 +1660,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get map_otherNodes => 'Other Nodes';
 
   @override
-  String get map_showOverlaps => 'Repeater Key Overlaps';
-
-  @override
   String get map_keyPrefix => 'Key Prefix';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1689,9 +1689,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get map_otherNodes => 'Otros Nodos';
 
   @override
-  String get map_showOverlaps => 'Superposiciones de tecla repetidora';
-
-  @override
   String get map_keyPrefix => 'Prefijo de clave';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1699,9 +1699,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get map_otherNodes => 'Autres nœuds';
 
   @override
-  String get map_showOverlaps => 'Chevauchement de la touche répétitive';
-
-  @override
   String get map_keyPrefix => 'Préfixe clé';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1701,9 +1701,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get map_otherNodes => 'Egyéb csomópontok';
 
   @override
-  String get map_showOverlaps => 'Az ismétlő kulcsok ütköznek';
-
-  @override
   String get map_keyPrefix => 'Kulcsfontosságú előtag';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1691,9 +1691,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get map_otherNodes => 'Altri Nodi';
 
   @override
-  String get map_showOverlaps => 'Sovrapposizioni della chiave ripetitore';
-
-  @override
   String get map_keyPrefix => 'Prefisso Chiave';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1618,9 +1618,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get map_otherNodes => 'その他のノード';
 
   @override
-  String get map_showOverlaps => 'リピーターキーの重複';
-
-  @override
   String get map_keyPrefix => '主要なプレフィックス';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1614,9 +1614,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get map_otherNodes => '다른 노드';
 
   @override
-  String get map_showOverlaps => '반복 키 중복';
-
-  @override
   String get map_keyPrefix => '핵심 접두사';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1678,9 +1678,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get map_otherNodes => 'Andere Nodes';
 
   @override
-  String get map_showOverlaps => 'Herhalingssleutel overlapt';
-
-  @override
   String get map_keyPrefix => 'Prefix sleutel';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1702,9 +1702,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get map_otherNodes => 'Inne węzły';
 
   @override
-  String get map_showOverlaps => 'Nakładające się klucze przekaźników';
-
-  @override
   String get map_keyPrefix => 'Prefiks klucza';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1690,9 +1690,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get map_otherNodes => 'Outros Nós';
 
   @override
-  String get map_showOverlaps => 'Sobreposições da Chave Repeater';
-
-  @override
   String get map_keyPrefix => 'Prefixo Chave';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1693,9 +1693,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get map_otherNodes => 'Другие ноды';
 
   @override
-  String get map_showOverlaps => 'Перекрытия ключа повтора';
-
-  @override
   String get map_keyPrefix => 'Префикс ключа';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1679,9 +1679,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get map_otherNodes => 'Ostatné uzly';
 
   @override
-  String get map_showOverlaps => 'Prekrývanie opakovača kľúča';
-
-  @override
   String get map_keyPrefix => 'Päťciferné predpona';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1675,9 +1675,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get map_otherNodes => 'Druge vozlišča';
 
   @override
-  String get map_showOverlaps => 'Prekrivanje ključa ponovnega predvajanja';
-
-  @override
   String get map_keyPrefix => 'Predpona ključa';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1668,9 +1668,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get map_otherNodes => 'Andra noder';
 
   @override
-  String get map_showOverlaps => 'Repeater-nyckelöverlappningar';
-
-  @override
   String get map_keyPrefix => 'Nyckelprefix';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1688,9 +1688,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get map_otherNodes => 'Інші вузли';
 
   @override
-  String get map_showOverlaps => 'Перекриття ключа повторювача';
-
-  @override
   String get map_keyPrefix => 'Префікс ключа';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1586,9 +1586,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get map_otherNodes => '其他节点';
 
   @override
-  String get map_showOverlaps => '重复键重叠';
-
-  @override
   String get map_keyPrefix => '关键字前缀';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Telemetrie-modus bijgewerkt",
   "settings_multiAck": "Multi-ACKs: {value}",
-  "map_showOverlaps": "Herhalingssleutel overlapt",
   "map_runTraceWithReturnPath": "Terugkeren op hetzelfde pad.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1980,7 +1980,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Tryb telemetryczny zaktualizowany",
   "settings_multiAck": "Wielokrotne ACK: {value}",
-  "map_showOverlaps": "Nakładające się klucze przekaźników",
   "map_runTraceWithReturnPath": "Wróć tą samą ścieżką",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Modo de telemetria atualizado",
   "settings_multiAck": "Multi-ACKs: {value}",
-  "map_showOverlaps": "Sobreposições da Chave Repeater",
   "map_runTraceWithReturnPath": "Retornar ao mesmo caminho.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1182,7 +1182,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Режим телеметрии обновлен",
   "settings_multiAck": "Мульти-ACK: {value}",
-  "map_showOverlaps": "Перекрытия ключа повтора",
   "map_runTraceWithReturnPath": "Вернуться обратно по тому же пути",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Režim telemetrie bol aktualizovaný",
   "settings_multiAck": "Viaceré ACK: {value}",
-  "map_showOverlaps": "Prekrývanie opakovača kľúča",
   "map_runTraceWithReturnPath": "Vráťte sa späť po tej istej ceste.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_multiAck": "Večkratni potrditvi: {value}",
   "settings_telemetryModeUpdated": "Način telemetrije posodobljen",
-  "map_showOverlaps": "Prekrivanje ključa ponovnega predvajanja",
   "map_runTraceWithReturnPath": "Vrni se nazaj po isti poti.",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Telemetri-läge uppdaterat",
   "settings_multiAck": "Multi-ACKs: {value}",
-  "map_showOverlaps": "Repeater-nyckelöverlappningar",
   "map_runTraceWithReturnPath": "Gå tillbaka på samma väg",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -1942,7 +1942,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_telemetryModeUpdated": "Режим телеметрії оновлено",
   "settings_multiAck": "Багатократне підтвердження: {value}",
-  "map_showOverlaps": "Перекриття ключа повторювача",
   "map_runTraceWithReturnPath": "Повернутися назад тим же шляхом",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1947,7 +1947,6 @@
   "path_routeWeight": "{weight}/{max}",
   "settings_multiAck": "多重ACK：{value}",
   "settings_telemetryModeUpdated": "遥测模式已更新",
-  "map_showOverlaps": "重复键重叠",
   "map_runTraceWithReturnPath": "沿着相同的路径返回",
   "@radioStats_noiseFloor": {
     "placeholders": {

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -20,7 +20,6 @@ class AppSettings {
   final bool mapShowRepeaters;
   final bool mapShowChatNodes;
   final bool mapShowOtherNodes;
-  final bool mapShowOverlaps;
   final double mapTimeFilterHours; // 0 = all time
   final bool mapKeyPrefixEnabled;
   final String mapKeyPrefix;
@@ -63,7 +62,6 @@ class AppSettings {
     this.mapShowRepeaters = true,
     this.mapShowChatNodes = true,
     this.mapShowOtherNodes = true,
-    this.mapShowOverlaps = false,
     this.mapTimeFilterHours = 0, // Default to all time
     this.mapKeyPrefixEnabled = false,
     this.mapKeyPrefix = '',
@@ -111,7 +109,6 @@ class AppSettings {
       'map_show_repeaters': mapShowRepeaters,
       'map_show_chat_nodes': mapShowChatNodes,
       'map_show_other_nodes': mapShowOtherNodes,
-      'map_show_overlaps': mapShowOverlaps,
       'map_time_filter_hours': mapTimeFilterHours,
       'map_key_prefix_enabled': mapKeyPrefixEnabled,
       'map_key_prefix': mapKeyPrefix,
@@ -166,7 +163,6 @@ class AppSettings {
       mapShowRepeaters: json['map_show_repeaters'] as bool? ?? true,
       mapShowChatNodes: json['map_show_chat_nodes'] as bool? ?? true,
       mapShowOtherNodes: json['map_show_other_nodes'] as bool? ?? true,
-      mapShowOverlaps: json['map_show_overlaps'] as bool? ?? false,
       mapTimeFilterHours:
           (json['map_time_filter_hours'] as num?)?.toDouble() ?? 0,
       mapKeyPrefixEnabled: json['map_key_prefix_enabled'] as bool? ?? false,
@@ -245,7 +241,6 @@ class AppSettings {
     bool? mapShowRepeaters,
     bool? mapShowChatNodes,
     bool? mapShowOtherNodes,
-    bool? mapShowOverlaps,
     double? mapTimeFilterHours,
     bool? mapKeyPrefixEnabled,
     String? mapKeyPrefix,
@@ -288,7 +283,6 @@ class AppSettings {
       mapShowRepeaters: mapShowRepeaters ?? this.mapShowRepeaters,
       mapShowChatNodes: mapShowChatNodes ?? this.mapShowChatNodes,
       mapShowOtherNodes: mapShowOtherNodes ?? this.mapShowOtherNodes,
-      mapShowOverlaps: mapShowOverlaps ?? this.mapShowOverlaps,
       mapTimeFilterHours: mapTimeFilterHours ?? this.mapTimeFilterHours,
       mapKeyPrefixEnabled: mapKeyPrefixEnabled ?? this.mapKeyPrefixEnabled,
       mapKeyPrefix: mapKeyPrefix ?? this.mapKeyPrefix,

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -489,11 +488,10 @@ class _MapScreenState extends State<MapScreen> {
                               ),
                             ),
                           ),
-                        if (!settings.mapShowOverlaps)
-                          ..._buildGuessedMarker(
-                            guessedLocations,
-                            showLabels: _showNodeLabels,
-                          ),
+                        ..._buildGuessedMarker(
+                          guessedLocations,
+                          showLabels: _showNodeLabels,
+                        ),
                         ..._buildMarkers(
                           contactsWithLocation,
                           settings,
@@ -863,9 +861,7 @@ class _MapScreenState extends State<MapScreen> {
 
       // Apply node type filters
       if (contact.type == advTypeRepeater &&
-          (settings.mapShowRepeaters ||
-              _isBuildingPathTrace ||
-              settings.mapShowOverlaps)) {
+          (settings.mapShowRepeaters || _isBuildingPathTrace)) {
         addContact = true;
       }
       if (contact.type == advTypeChat &&
@@ -874,33 +870,12 @@ class _MapScreenState extends State<MapScreen> {
       }
       if (contact.type != advTypeChat &&
           contact.type != advTypeRepeater &&
-          (settings.mapShowOtherNodes ||
-              _isBuildingPathTrace ||
-              settings.mapShowOverlaps)) {
+          (settings.mapShowOtherNodes || _isBuildingPathTrace)) {
         addContact = true;
       }
 
       if (contact.type == advTypeChat && _isBuildingPathTrace) {
         addContact = false;
-      }
-
-      if (settings.mapShowOverlaps) {
-        final hasOverlap = contacts
-            .where(
-              (c) =>
-                  c.publicKeyHex != contact.publicKeyHex &&
-                  c.publicKey.first == contact.publicKey.first &&
-                  (c.type == advTypeRepeater || c.type == advTypeRoom) &&
-                  (contact.type == advTypeRepeater ||
-                      contact.type == advTypeRoom),
-            )
-            .firstOrNull;
-
-        if (hasOverlap == null &&
-            settings.mapShowOverlaps &&
-            !_isBuildingPathTrace) {
-          addContact = false;
-        }
       }
 
       if (addContact) {
@@ -933,9 +908,7 @@ class _MapScreenState extends State<MapScreen> {
               Container(
                 padding: const EdgeInsets.all(4),
                 decoration: BoxDecoration(
-                  color: settings.mapShowOverlaps && !_isBuildingPathTrace
-                      ? Colors.red
-                      : _getNodeColor(contact.type),
+                  color: _getNodeColor(contact.type),
                   shape: BoxShape.circle,
                   border: Border.all(color: Colors.white, width: 2),
                   boxShadow: [
@@ -962,9 +935,7 @@ class _MapScreenState extends State<MapScreen> {
         markers.add(
           _buildNodeLabelMarker(
             point: LatLng(contact.latitude!, contact.longitude!),
-            label: settings.mapShowOverlaps && !_isBuildingPathTrace
-                ? "${contact.publicKeyHex.substring(0, 2)}:${contact.name}"
-                : contact.name,
+            label: contact.name,
           ),
         );
       }
@@ -1976,14 +1947,6 @@ class _MapScreenState extends State<MapScreen> {
                     value: settings.mapShowDiscoveryContacts,
                     onChanged: (value) {
                       service.setMapShowDiscoveryContacts(value ?? true);
-                    },
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                  CheckboxListTile(
-                    title: Text(context.l10n.map_showOverlaps),
-                    value: settings.mapShowOverlaps,
-                    onChanged: (value) {
-                      service.setMapShowOverlaps(value ?? true);
                     },
                     contentPadding: EdgeInsets.zero,
                   ),

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -65,10 +65,6 @@ class AppSettingsService extends ChangeNotifier {
     await updateSettings(_settings.copyWith(mapShowOtherNodes: value));
   }
 
-  Future<void> setMapShowOverlaps(bool value) async {
-    await updateSettings(_settings.copyWith(mapShowOverlaps: value));
-  }
-
   Future<void> setMapTimeFilterHours(double value) async {
     await updateSettings(_settings.copyWith(mapTimeFilterHours: value));
   }


### PR DESCRIPTION
This PR removes the feature to mark Repeaters with matching Prefixes as Red.

As also in Issue #352 explained, this is of no usage anymore:
This is due to the fact, that with the Discovery list (unlimited appstorage) you can get so many repeaters,
that you have multiple matches for every Repeater prefix, resulting just in marking every Repeater red without additional information gain.
For 1500 Repeaters and a one byte Prefix you get about 5 matches for every prefix.

Additionally the calculation is done in a repeater ^ 2 search method, and this not only once on map load, but on every map interaction (move/zoom).
(In my previous PR #298 I implemented a repeater ^ 1 approach to keep the functionality, but as written above I would now advertise to remove this.)

PS: I hope it is right to base it on dev-branch?
