### PR TITLE
Pin favorited contacts to the top of the contacts list

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -264,6 +264,8 @@
   "appSettings_languageUk": "Українська",
   "appSettings_enableMessageTracing": "Enable Message Tracing",
   "appSettings_enableMessageTracingSubtitle": "Show detailed routing and timing metadata for messages",
+  "appSettings_enableFavoritesSection": "Separate Favorites Section",
+  "appSettings_enableFavoritesSectionSubtitle": "Show separate favorites section at top of contacts",
   "appSettings_notifications": "Notifications",
   "appSettings_enableNotifications": "Enable Notifications",
   "appSettings_enableNotificationsSubtitle": "Receive notifications for messages and adverts",
@@ -2147,6 +2149,8 @@
   "contacts_zeroHopContactAdvertFailed": "Failed to send contact.",
   "contacts_contactAdvertCopied": "Advert copied to Clipboard.",
   "contacts_contactAdvertCopyFailed": "Copying advert to Clipboard failed.",
+  "contacts_sectionFavorites": "Favorites",
+  "contacts_sectionAll": "All Contacts",
   "notification_activityTitle": "MeshCore Activity",
   "notification_messagesCount": "{count} {count, plural, =1{message} other{messages}}",
   "@notification_messagesCount": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1336,6 +1336,18 @@ abstract class AppLocalizations {
   /// **'Show detailed routing and timing metadata for messages'**
   String get appSettings_enableMessageTracingSubtitle;
 
+  /// No description provided for @appSettings_enableFavoritesSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate Favorites Section'**
+  String get appSettings_enableFavoritesSection;
+
+  /// No description provided for @appSettings_enableFavoritesSectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show separate favorites section at top of contacts'**
+  String get appSettings_enableFavoritesSectionSubtitle;
+
   /// No description provided for @appSettings_notifications.
   ///
   /// In en, this message translates to:
@@ -6687,6 +6699,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Copying advert to Clipboard failed.'**
   String get contacts_contactAdvertCopyFailed;
+
+  /// No description provided for @contacts_sectionFavorites.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorites'**
+  String get contacts_sectionFavorites;
+
+  /// No description provided for @contacts_sectionAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All Contacts'**
+  String get contacts_sectionAll;
 
   /// No description provided for @notification_activityTitle.
   ///

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -675,6 +675,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на подробни метаданни за маршрутизация и синхронизация за съобщения';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Уведомления';
 
   @override
@@ -3878,6 +3885,12 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Копирането на обявата в клипборда не успя.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Активност на MeshCore';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -670,6 +670,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Detaillierte Routing- und Timing-Metadaten für Nachrichten anzeigen';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Benachrichtigungen';
 
   @override
@@ -3892,6 +3899,12 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Kopieren der Ankündigung in die Zwischenablage fehlgeschlagen.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'MeshCore Aktivität';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -659,6 +659,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show detailed routing and timing metadata for messages';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Notifications';
 
   @override
@@ -3810,6 +3817,12 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Copying advert to Clipboard failed.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'MeshCore Activity';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -671,6 +671,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar metadatos detallados de enrutamiento y tiempo para los mensajes';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Notificaciones';
 
   @override
@@ -3878,6 +3885,12 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Copiar anuncio al Portapapeles ha fallado.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Actividad de MeshCore';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -675,6 +675,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les métadonnées détaillées de routage et de synchronisation des messages';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Notifications';
 
   @override
@@ -3904,6 +3911,12 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'La copie de l\'annonce vers le presse-papiers a échoué.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Activité MeshCore';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -675,6 +675,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Adja meg a üzenetek részletes útvonal- és időzítési adatokat.';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Értesítések';
 
   @override
@@ -3896,6 +3903,12 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Az hirdetés másolása a vágólapra sikertelen.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'MeshCore tevékenységek';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -673,6 +673,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra metadati dettagliati su instradamento e tempi per i messaggi';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Notifiche';
 
   @override
@@ -3885,6 +3892,12 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Copia dell\'annuncio nella Clipboard non riuscita.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Attività MeshCore';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -645,6 +645,13 @@ class AppLocalizationsJa extends AppLocalizations {
       'メッセージに関する詳細な経路およびタイミングに関するメタデータを表示する';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => '通知';
 
   @override
@@ -3677,6 +3684,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get contacts_contactAdvertCopyFailed => '広告のコピーがクリップボードにコピーできませんでした。';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'メッシュコアの活動';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -645,6 +645,13 @@ class AppLocalizationsKo extends AppLocalizations {
       '메시지에 대한 상세한 경로 및 시간 정보를 표시';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => '알림';
 
   @override
@@ -3679,6 +3686,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get contacts_contactAdvertCopyFailed => '광고를 클립보드에 복사하는 데 실패했습니다.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => '메쉬코어 활동';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -666,6 +666,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Gedetailleerde routerings- en timing-metadata voor berichten weergeven';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Notificaties';
 
   @override
@@ -3865,6 +3872,12 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Kopiëren van advertentie naar Clipboard is mislukt.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'MeshCore Activiteit';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -675,6 +675,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Pokaż szczegółowe metadane trasowania i czasu dla wiadomości';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Powiadomienia';
 
   @override
@@ -3896,6 +3903,12 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Kopiowanie rozgłoszenia do schowka nie powiodło się.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Aktywność MeshCore';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -673,6 +673,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar metadados detalhados de roteamento e tempo para as mensagens';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Notificações';
 
   @override
@@ -3876,6 +3883,12 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Cópia do anúncio para a Área de Transferência falhou.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Atividade MeshCore';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -673,6 +673,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показывать подробные метаданные о маршрутизации и времени для сообщений';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Уведомления';
 
   @override
@@ -3888,6 +3895,12 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Копирование рекламы в буфер обмена не удалось.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Активность MeshCore';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -666,6 +666,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobraziť podrobné metadáta o smerovaní a časovaní správ';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Upozornenia';
 
   @override
@@ -3859,6 +3866,12 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Kopírovanie inzerátu do schránky zlyhalo.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Aktivita MeshCore';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -663,6 +663,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Prikaži podrobne metapodatke o usmerjanju in časovnem usklajevanju sporočil';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Obvestila';
 
   @override
@@ -3853,6 +3860,12 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Kopiranje oglasa v odložišče je spodletelo.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Aktivnost MeshCore';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -661,6 +661,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Visa detaljerade metadata om dirigering och tidsinställningar för meddelanden';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Meddelanden';
 
   @override
@@ -3831,6 +3838,12 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Kopiering av annons till Urklipp misslyckades.';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'MeshCore Aktivitet';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -670,6 +670,13 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показувати детальні метадані про маршрутизацію та час для повідомлень';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => 'Сповіщення';
 
   @override
@@ -3887,6 +3894,12 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get contacts_contactAdvertCopyFailed =>
       'Копіювання оголошення в буфер обміну завершилось невдало';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'Активність MeshCore';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -635,6 +635,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get appSettings_enableMessageTracingSubtitle => '显示消息的详细路由和时间元数据';
 
   @override
+  String get appSettings_enableFavoritesSection => 'Separate Favorites Section';
+
+  @override
+  String get appSettings_enableFavoritesSectionSubtitle =>
+      'Show separate favorites section at top of contacts';
+
+  @override
   String get appSettings_notifications => '通知';
 
   @override
@@ -3580,6 +3587,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get contacts_contactAdvertCopyFailed => '复制广播到剪贴板失败。';
+
+  @override
+  String get contacts_sectionFavorites => 'Favorites';
+
+  @override
+  String get contacts_sectionAll => 'All Contacts';
 
   @override
   String get notification_activityTitle => 'MeshCore 活动';

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -88,6 +88,7 @@ class AppSettings {
   final bool mapShowMarkers;
   final bool mapShowGuessedLocations;
   final bool enableMessageTracing;
+  final bool enableFavoritesSection;
   final Map<String, double>? mapCacheBounds;
   final int mapCacheMinZoom;
   final int mapCacheMaxZoom;
@@ -141,6 +142,7 @@ class AppSettings {
     this.mapShowMarkers = true,
     this.mapShowGuessedLocations = true,
     this.enableMessageTracing = false,
+    this.enableFavoritesSection = false,
     this.mapCacheBounds,
     this.mapCacheMinZoom = 10,
     this.mapCacheMaxZoom = 15,
@@ -201,6 +203,7 @@ class AppSettings {
       'map_show_markers': mapShowMarkers,
       'map_show_guessed_locations': mapShowGuessedLocations,
       'enable_message_tracing': enableMessageTracing,
+      'enable_favorites_section': enableFavoritesSection,
       'map_cache_bounds': mapCacheBounds,
       'map_cache_min_zoom': mapCacheMinZoom,
       'map_cache_max_zoom': mapCacheMaxZoom,
@@ -262,6 +265,8 @@ class AppSettings {
       mapShowGuessedLocations:
           json['map_show_guessed_locations'] as bool? ?? true,
       enableMessageTracing: json['enable_message_tracing'] as bool? ?? false,
+      enableFavoritesSection:
+          json['enable_favorites_section'] as bool? ?? false,
       mapCacheBounds: (json['map_cache_bounds'] as Map?)?.map(
         (key, value) => MapEntry(key.toString(), (value as num).toDouble()),
       ),
@@ -371,6 +376,7 @@ class AppSettings {
     bool? mapShowMarkers,
     bool? mapShowGuessedLocations,
     bool? enableMessageTracing,
+    bool? enableFavoritesSection,
     Object? mapCacheBounds = _unset,
     int? mapCacheMinZoom,
     int? mapCacheMaxZoom,
@@ -417,6 +423,8 @@ class AppSettings {
       mapShowGuessedLocations:
           mapShowGuessedLocations ?? this.mapShowGuessedLocations,
       enableMessageTracing: enableMessageTracing ?? this.enableMessageTracing,
+      enableFavoritesSection:
+          enableFavoritesSection ?? this.enableFavoritesSection,
       mapCacheBounds: mapCacheBounds == _unset
           ? this.mapCacheBounds
           : mapCacheBounds as Map<String, double>?,

--- a/lib/screens/app_settings_screen.dart
+++ b/lib/screens/app_settings_screen.dart
@@ -121,6 +121,18 @@ class AppSettingsScreen extends StatelessWidget {
               settingsService.setEnableMessageTracing(value);
             },
           ),
+          const Divider(height: 1),
+          SwitchListTile(
+            secondary: const Icon(Icons.star_rounded),
+            title: Text(context.l10n.appSettings_enableFavoritesSection),
+            subtitle: Text(
+              context.l10n.appSettings_enableFavoritesSectionSubtitle,
+            ),
+            value: settingsService.settings.enableFavoritesSection,
+            onChanged: (value) {
+              settingsService.setEnableFavoritesSection(value);
+            },
+          ),
         ],
       ),
     );

--- a/lib/screens/contacts_screen.dart
+++ b/lib/screens/contacts_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:meshcore_open/screens/path_trace_map.dart';
+import 'package:meshcore_open/services/app_settings_service.dart';
 import 'package:meshcore_open/services/notification_service.dart';
 import 'package:meshcore_open/utils/app_logger.dart';
 import 'package:meshcore_open/utils/platform_info.dart';
@@ -602,6 +603,7 @@ class _ContactsScreenState extends State<ContactsScreen>
   }
 
   Widget _buildContactsBody(BuildContext context, MeshCoreConnector connector) {
+    final settings = context.watch<AppSettingsService>().settings;
     final viewState = context.watch<UiViewStateService>();
     final contacts = connector.contacts;
     final shouldShowStartupSpinner =
@@ -806,21 +808,62 @@ class _ContactsScreenState extends State<ContactsScreen>
                 )
               : RefreshIndicator(
                   onRefresh: () => connector.getContacts(),
-                  child: ListView.builder(
-                    itemCount: filteredAndSorted.length,
-                    itemBuilder: (context, index) {
-                      final contact = filteredAndSorted[index];
-                      final unreadCount = connector.getUnreadCountForContact(
-                        contact,
-                      );
-                      return _ContactTile(
-                        contact: contact,
-                        lastSeen: _resolveLastSeen(contact),
-                        unreadCount: unreadCount,
-                        isFavorite: contact.isFavorite,
-                        onTap: () => _openChat(context, contact),
-                        onLongPress: () =>
-                            _showContactOptions(context, connector, contact),
+                  child: Builder(
+                    builder: (context) {
+                      final List<Contact> favorites;
+                      final List<Contact> others;
+                      if (settings.enableFavoritesSection) {
+                        favorites = filteredAndSorted
+                            .where((n) => n.isFavorite)
+                            .toList();
+                        others = filteredAndSorted
+                            .where((n) => !n.isFavorite)
+                            .toList();
+                      } else {
+                        favorites = [];
+                        others = filteredAndSorted;
+                      }
+                      final hasFavorites = favorites.isNotEmpty;
+                      final showOthersHeader =
+                          hasFavorites && others.isNotEmpty;
+                      // Total rows = favorites header? + favorites + others header? + others
+                      final itemCount =
+                          (hasFavorites ? 1 : 0) +
+                          favorites.length +
+                          (showOthersHeader ? 1 : 0) +
+                          others.length;
+                      return ListView.builder(
+                        itemCount: itemCount,
+                        itemBuilder: (context, index) {
+                          var i = index;
+                          if (hasFavorites) {
+                            if (i == 0) {
+                              return _sectionHeader(
+                                context,
+                                context.l10n.contacts_sectionFavorites,
+                              );
+                            }
+                            i -= 1;
+                          }
+                          // Favorite contacts
+                          if (i < favorites.length) {
+                            return _buildTile(context, connector, favorites[i]);
+                          }
+                          i -= favorites.length;
+
+                          // Others header
+                          if (showOthersHeader) {
+                            if (i == 0) {
+                              return _sectionHeader(
+                                context,
+                                context.l10n.contacts_sectionAll,
+                              );
+                            }
+                            i -= 1;
+                          }
+                          // Other contacts
+                          return _buildTile(context, connector, others[i]);
+                        },
                       );
                     },
                   ),
@@ -1443,6 +1486,34 @@ class _ContactsScreenState extends State<ContactsScreen>
           ),
         ],
       ),
+    );
+  }
+
+  Widget _sectionHeader(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTile(
+    BuildContext context,
+    MeshCoreConnector connector,
+    Contact contact,
+  ) {
+    return _ContactTile(
+      contact: contact,
+      lastSeen: _resolveLastSeen(contact),
+      unreadCount: connector.getUnreadCountForContact(contact),
+      isFavorite: contact.isFavorite,
+      onTap: () => _openChat(context, contact),
+      onLongPress: () => _showContactOptions(context, connector, contact),
     );
   }
 }

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -100,6 +100,10 @@ class AppSettingsService extends ChangeNotifier {
     await updateSettings(_settings.copyWith(enableMessageTracing: value));
   }
 
+  Future<void> setEnableFavoritesSection(bool value) async {
+    await updateSettings(_settings.copyWith(enableFavoritesSection: value));
+  }
+
   Future<void> setMapCacheBounds(Map<String, double>? value) async {
     await updateSettings(_settings.copyWith(mapCacheBounds: value));
   }

--- a/untranslated.json
+++ b/untranslated.json
@@ -1,1 +1,120 @@
-{}
+{
+  "bg": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "de": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "es": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "fr": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "hu": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "it": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "ja": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "ko": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "nl": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "pl": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "pt": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "ru": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "sk": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "sl": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "sv": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "uk": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ],
+
+  "zh": [
+    "appSettings_enableFavoritesSection",
+    "appSettings_enableFavoritesSectionSubtitle",
+    "contacts_sectionFavorites",
+    "contacts_sectionAll"
+  ]
+}


### PR DESCRIPTION
When you have a large number of contacts, it's usually nice to have favorited contacts appear at the top of the contacts page. You can already filter the list to show only favorites, but having your personal repeater (or similar) always pinned at the top is a small usability win.


## Changes

Favorited contacts are grouped at the top under a "Favorites" header, with the rest under "All Contacts".
When there are no favorites, the list renders exactly as before — no headers.
Existing sort, filter, search, and group selection all still apply within each section.


Section headers are hardcoded English for now. But i am happy to localize via context.l10n in this PR or as a follow-up.