### PR TITLE
Add tap-to-dismiss keyboard in chat lists

### DIFF
--- a/lib/screens/channel_chat_screen.dart
+++ b/lib/screens/channel_chat_screen.dart
@@ -323,58 +323,67 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                   return Stack(
                     children: [
                       ChatZoomWrapper(
-                        child: ListView.builder(
-                          reverse: true, // List grows from bottom up
-                          controller: _scrollController,
-                          padding: const EdgeInsets.all(8),
-                          itemCount: itemCount,
-                          itemBuilder: (context, index) {
-                            // Loading indicator now appears at end (bottom) of reversed list
-                            if (_isLoadingOlder && index == itemCount - 1) {
-                              return const Padding(
-                                padding: EdgeInsets.symmetric(vertical: 16),
-                                child: Center(
-                                  child: SizedBox(
-                                    width: 20,
-                                    height: 20,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.translucent,
+                          onTap: () => FocusScope.of(context).unfocus(),
+                          child: ListView.builder(
+                            reverse: true, // List grows from bottom up
+                            controller: _scrollController,
+                            padding: const EdgeInsets.all(8),
+                            itemCount: itemCount,
+                            itemBuilder: (context, index) {
+                              // Loading indicator now appears at end (bottom) of reversed list
+                              if (_isLoadingOlder && index == itemCount - 1) {
+                                return const Padding(
+                                  padding: EdgeInsets.symmetric(vertical: 16),
+                                  child: Center(
+                                    child: SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
                                     ),
                                   ),
+                                );
+                              }
+                              final messageIndex = index;
+                              final message = reversedMessages[messageIndex];
+                              if (!_messageKeys.containsKey(
+                                message.messageId,
+                              )) {
+                                _messageKeys[message.messageId] = GlobalKey();
+                              }
+                              final isUnreadAnchor =
+                                  _unreadDividerMessageId != null &&
+                                  message.messageId == _unreadDividerMessageId;
+                              return Container(
+                                key: _messageKeys[message.messageId]!,
+                                child: Builder(
+                                  builder: (context) {
+                                    final textScale = context
+                                        .select<ChatTextScaleService, double>(
+                                          (service) => service.scale,
+                                        );
+                                    final bubble = _buildMessageBubble(
+                                      message,
+                                      textScale,
+                                    );
+                                    if (isUnreadAnchor) {
+                                      return Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          const UnreadDivider(),
+                                          bubble,
+                                        ],
+                                      );
+                                    }
+                                    return bubble;
+                                  },
                                 ),
                               );
-                            }
-                            final messageIndex = index;
-                            final message = reversedMessages[messageIndex];
-                            if (!_messageKeys.containsKey(message.messageId)) {
-                              _messageKeys[message.messageId] = GlobalKey();
-                            }
-                            final isUnreadAnchor =
-                                _unreadDividerMessageId != null &&
-                                message.messageId == _unreadDividerMessageId;
-                            return Container(
-                              key: _messageKeys[message.messageId]!,
-                              child: Builder(
-                                builder: (context) {
-                                  final textScale = context
-                                      .select<ChatTextScaleService, double>(
-                                        (service) => service.scale,
-                                      );
-                                  final bubble = _buildMessageBubble(
-                                    message,
-                                    textScale,
-                                  );
-                                  if (isUnreadAnchor) {
-                                    return Column(
-                                      mainAxisSize: MainAxisSize.min,
-                                      children: [const UnreadDivider(), bubble],
-                                    );
-                                  }
-                                  return bubble;
-                                },
-                              ),
-                            );
-                          },
+                            },
+                          ),
                         ),
                       ),
                       JumpToBottomButton(scrollController: _scrollController),

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -460,77 +460,81 @@ class _ChatScreenState extends State<ChatScreen> {
     });
 
     return ChatZoomWrapper(
-      child: ListView.builder(
-        reverse: true, // List grows from bottom up
-        controller: _scrollController,
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-        itemCount: itemCount,
-        itemBuilder: (context, index) {
-          // Loading indicator now appears at end (bottom) of reversed list
-          if (_isLoadingOlder && index == itemCount - 1) {
-            return const Padding(
-              padding: EdgeInsets.symmetric(vertical: 16),
-              child: Center(
-                child: SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: ListView.builder(
+          reverse: true, // List grows from bottom up
+          controller: _scrollController,
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+          itemCount: itemCount,
+          itemBuilder: (context, index) {
+            // Loading indicator now appears at end (bottom) of reversed list
+            if (_isLoadingOlder && index == itemCount - 1) {
+              return const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Center(
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
                 ),
-              ),
-            );
-          }
-          final messageIndex = index;
-          Contact contact = _resolveContact(connector);
-          final message = reversedMessages[messageIndex];
-          String fourByteHex = '';
-          if (contact.type == advTypeRoom) {
-            contact = _resolveContactFrom4Bytes(
-              connector,
-              message.fourByteRoomContactKey.isEmpty
-                  ? Uint8List.fromList([0, 0, 0, 0])
-                  : message.fourByteRoomContactKey,
-            );
-            fourByteHex = message.fourByteRoomContactKey
-                .map((b) => b.toRadixString(16).padLeft(2, '0'))
-                .join()
-                .toUpperCase();
-          }
+              );
+            }
+            final messageIndex = index;
+            Contact contact = _resolveContact(connector);
+            final message = reversedMessages[messageIndex];
+            String fourByteHex = '';
+            if (contact.type == advTypeRoom) {
+              contact = _resolveContactFrom4Bytes(
+                connector,
+                message.fourByteRoomContactKey.isEmpty
+                    ? Uint8List.fromList([0, 0, 0, 0])
+                    : message.fourByteRoomContactKey,
+              );
+              fourByteHex = message.fourByteRoomContactKey
+                  .map((b) => b.toRadixString(16).padLeft(2, '0'))
+                  .join()
+                  .toUpperCase();
+            }
 
-          return Builder(
-            builder: (context) {
-              final textScale = context.select<ChatTextScaleService, double>(
-                (service) => service.scale,
-              );
-              final resolvedContact = _resolveContact(connector);
-              final bubble = _MessageBubble(
-                message: message,
-                senderName: resolvedContact.type == advTypeRoom
-                    ? "${contact.name} [$fourByteHex]"
-                    : contact.name,
-                sourceId: widget.contact.publicKeyHex,
-                isRoomServer: resolvedContact.type == advTypeRoom,
-                textScale: textScale,
-                onTap: () => _openMessagePath(message, contact),
-                onLongPress: () => _showMessageActions(message, contact),
-                onRetryReaction: (msg, emoji) =>
-                    _sendReaction(msg, contact, emoji),
-              );
-              final isUnreadAnchor =
-                  _unreadDividerMessageId != null &&
-                  message.messageId == _unreadDividerMessageId;
-              final child = isUnreadAnchor
-                  ? Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [const UnreadDivider(), bubble],
-                    )
-                  : bubble;
-              if (identical(message, _pendingUnreadScrollTarget)) {
-                return KeyedSubtree(key: _unreadScrollKey, child: child);
-              }
-              return child;
-            },
-          );
-        },
+            return Builder(
+              builder: (context) {
+                final textScale = context.select<ChatTextScaleService, double>(
+                  (service) => service.scale,
+                );
+                final resolvedContact = _resolveContact(connector);
+                final bubble = _MessageBubble(
+                  message: message,
+                  senderName: resolvedContact.type == advTypeRoom
+                      ? "${contact.name} [$fourByteHex]"
+                      : contact.name,
+                  sourceId: widget.contact.publicKeyHex,
+                  isRoomServer: resolvedContact.type == advTypeRoom,
+                  textScale: textScale,
+                  onTap: () => _openMessagePath(message, contact),
+                  onLongPress: () => _showMessageActions(message, contact),
+                  onRetryReaction: (msg, emoji) =>
+                      _sendReaction(msg, contact, emoji),
+                );
+                final isUnreadAnchor =
+                    _unreadDividerMessageId != null &&
+                    message.messageId == _unreadDividerMessageId;
+                final child = isUnreadAnchor
+                    ? Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [const UnreadDivider(), bubble],
+                      )
+                    : bubble;
+                if (identical(message, _pendingUnreadScrollTarget)) {
+                  return KeyedSubtree(key: _unreadScrollKey, child: child);
+                }
+                return child;
+              },
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
# Summary
This PR improves chat usability by dismissing the keyboard when users tap anywhere in the message list area.

# Problem
On both direct chat and channel chat screens, the keyboard could remain open unless users explicitly closed it, which reduced visible message area and made navigation less convenient.

# Solution
Wrapped each chat message list with a tap handler that unfocuses the current input field:

Added a transparent tap target around the message list
On tap, calls focus unfocus to close the keyboard
Kept existing list behavior unchanged (reverse list, unread divider, loading older messages, jump-to-bottom behavior)

# Testing
Manual verification performed:

Open direct chat, focus input, tap empty/list area, keyboard dismisses.
Open channel chat, focus input, tap empty/list area, keyboard dismisses.
Confirm message list interactions still work (scrolling, unread divider placement, loading indicator, jump-to-bottom).