### PR TITLE
Add "NRF52" as a device name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Devices are discovered by scanning for BLE advertisements with known MeshCore de
     - `WisCore-`
     - `HT-`
     - `LowMesh_MC_`
+    - `NRF52`
 
 New device prefixes can be added in `lib/connector/meshcore_uuids.dart`.
 

--- a/lib/connector/meshcore_uuids.dart
+++ b/lib/connector/meshcore_uuids.dart
@@ -11,5 +11,6 @@ class MeshCoreUuids {
     "Lilygo",
     "HT-",
     "LowMesh_MC_",
+    "NRF52",
   ];
 }


### PR DESCRIPTION
Hello, for some reason, my T-Echo decides to rename itself to "NRF52 DK", which breaks the app from being able to discover it. I think this might be caused by the node name being too long to fit in a bluetooth device name, but this is fixes it anyways. I tested it on my phone and it resolves the issue.