### PR TITLE
Add Russian regional presets

### DIFF
--- a/lib/models/radio_settings.dart
+++ b/lib/models/radio_settings.dart
@@ -182,6 +182,286 @@ class RadioSettings {
       ),
     ),
     (
+      'Russia Biysk (BSK)',
+      RadioSettings(
+        frequencyMHz: 869.000,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_5,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Cherepovets (CEE)',
+      RadioSettings(
+        frequencyMHz: 868.570,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Chelyabinsk (CEK)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Nizhny Novgorod (GOJ)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Saratov (GSV)',
+      RadioSettings(
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia St. Petersburg (LED)',
+      RadioSettings(
+        frequencyMHz: 868.856,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Izhevsk (IJK)',
+      RadioSettings(
+        frequencyMHz: 868.732,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Irkutsk (IKT)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Ivanovo (IWA)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Khabarovsk (KHV)',
+      RadioSettings(
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Tver (KLD)',
+      RadioSettings(
+        frequencyMHz: 869.169,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Kaluga (KLF)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Samara (KUF)',
+      RadioSettings(
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Kirov (KVX)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Kazan (KZN)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Lipetsk (LPK)',
+      RadioSettings(
+        frequencyMHz: 868.950,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf9,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Moscow (MOW)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Novosibirsk (OVB)',
+      RadioSettings(
+        frequencyMHz: 869.000,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf9,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Rostov-on-Don (ROV)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf9,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Ryazan (RZN)',
+      RadioSettings(
+        frequencyMHz: 868.880,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf9,
+        codingRate: LoRaCodingRate.cr4_5,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Yekaterinburg (SVX)',
+      RadioSettings(
+        frequencyMHz: 869.046,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Tambov (TBW)',
+      RadioSettings(
+        frequencyMHz: 868.950,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf10,
+        codingRate: LoRaCodingRate.cr4_5,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Tula (TYA)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Ufa (UFA)',
+      RadioSettings(
+        frequencyMHz: 868.732,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_8,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Volgograd (VOG)',
+      RadioSettings(
+        frequencyMHz: 869.525,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Voronezh (VOZ)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Lugansk (VSG)',
+      RadioSettings(
+        frequencyMHz: 868.825,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf7,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Artyom (VVO)',
+      RadioSettings(
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
       'Switzerland',
       RadioSettings(
         frequencyMHz: 869.618,

--- a/lib/models/radio_settings.dart
+++ b/lib/models/radio_settings.dart
@@ -182,22 +182,22 @@ class RadioSettings {
       ),
     ),
     (
+      'Russia Artyom (VVO)',
+      RadioSettings(
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
       'Russia Biysk (BSK)',
       RadioSettings(
         frequencyMHz: 869.000,
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf8,
         codingRate: LoRaCodingRate.cr4_5,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia Cherepovets (CEE)',
-      RadioSettings(
-        frequencyMHz: 868.570,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf7,
-        codingRate: LoRaCodingRate.cr4_8,
         txPowerDbm: 20,
       ),
     ),
@@ -212,41 +212,11 @@ class RadioSettings {
       ),
     ),
     (
-      'Russia Nizhny Novgorod (GOJ)',
+      'Russia Cherepovets (CEE)',
       RadioSettings(
-        frequencyMHz: 868.731,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf8,
-        codingRate: LoRaCodingRate.cr4_6,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia Saratov (GSV)',
-      RadioSettings(
-        frequencyMHz: 864.281,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf8,
-        codingRate: LoRaCodingRate.cr4_7,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia St. Petersburg (LED)',
-      RadioSettings(
-        frequencyMHz: 868.856,
+        frequencyMHz: 868.570,
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf7,
-        codingRate: LoRaCodingRate.cr4_7,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia Izhevsk (IJK)',
-      RadioSettings(
-        frequencyMHz: 868.732,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf8,
         codingRate: LoRaCodingRate.cr4_8,
         txPowerDbm: 20,
       ),
@@ -272,19 +242,9 @@ class RadioSettings {
       ),
     ),
     (
-      'Russia Khabarovsk (KHV)',
+      'Russia Izhevsk (IJK)',
       RadioSettings(
-        frequencyMHz: 864.281,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf8,
-        codingRate: LoRaCodingRate.cr4_6,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia Tver (KLD)',
-      RadioSettings(
-        frequencyMHz: 869.169,
+        frequencyMHz: 868.732,
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf8,
         codingRate: LoRaCodingRate.cr4_8,
@@ -302,12 +262,22 @@ class RadioSettings {
       ),
     ),
     (
-      'Russia Samara (KUF)',
+      'Russia Kazan (KZN)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Khabarovsk (KHV)',
       RadioSettings(
         frequencyMHz: 864.281,
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf8,
-        codingRate: LoRaCodingRate.cr4_7,
+        codingRate: LoRaCodingRate.cr4_6,
         txPowerDbm: 20,
       ),
     ),
@@ -318,16 +288,6 @@ class RadioSettings {
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf8,
         codingRate: LoRaCodingRate.cr4_8,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia Kazan (KZN)',
-      RadioSettings(
-        frequencyMHz: 868.731,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf8,
-        codingRate: LoRaCodingRate.cr4_6,
         txPowerDbm: 20,
       ),
     ),
@@ -348,6 +308,16 @@ class RadioSettings {
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf7,
         codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Nizhny Novgorod (GOJ)',
+      RadioSettings(
+        frequencyMHz: 868.731,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_6,
         txPowerDbm: 20,
       ),
     ),
@@ -382,9 +352,29 @@ class RadioSettings {
       ),
     ),
     (
-      'Russia Yekaterinburg (SVX)',
+      'Russia Samara (KUF)',
       RadioSettings(
-        frequencyMHz: 869.046,
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Saratov (GSV)',
+      RadioSettings(
+        frequencyMHz: 864.281,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia St. Petersburg (LED)',
+      RadioSettings(
+        frequencyMHz: 868.856,
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf7,
         codingRate: LoRaCodingRate.cr4_7,
@@ -408,6 +398,16 @@ class RadioSettings {
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf8,
         codingRate: LoRaCodingRate.cr4_7,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
+      'Russia Tver (KLD)',
+      RadioSettings(
+        frequencyMHz: 869.169,
+        bandwidth: LoRaBandwidth.bw62_5,
+        spreadingFactor: LoRaSpreadingFactor.sf8,
+        codingRate: LoRaCodingRate.cr4_8,
         txPowerDbm: 20,
       ),
     ),
@@ -442,22 +442,12 @@ class RadioSettings {
       ),
     ),
     (
-      'Russia Lugansk (VSG)',
+      'Russia Yekaterinburg (SVX)',
       RadioSettings(
-        frequencyMHz: 868.825,
+        frequencyMHz: 869.046,
         bandwidth: LoRaBandwidth.bw62_5,
         spreadingFactor: LoRaSpreadingFactor.sf7,
         codingRate: LoRaCodingRate.cr4_7,
-        txPowerDbm: 20,
-      ),
-    ),
-    (
-      'Russia Artyom (VVO)',
-      RadioSettings(
-        frequencyMHz: 864.281,
-        bandwidth: LoRaBandwidth.bw62_5,
-        spreadingFactor: LoRaSpreadingFactor.sf8,
-        codingRate: LoRaCodingRate.cr4_6,
         txPowerDbm: 20,
       ),
     ),


### PR DESCRIPTION
Add Russian regional presets based on https://meshcoretel.ru/ data:
```
Russia Artyom (VVO)
Russia Biysk (BSK)
Russia Chelyabinsk (CEK)
Russia Cherepovets (CEE)
Russia Irkutsk (IKT)
Russia Ivanovo (IWA)
Russia Izhevsk (IJK)
Russia Kaluga (KLF)
Russia Kazan (KZN)
Russia Khabarovsk (KHV)
Russia Kirov (KVX)
Russia Lipetsk (LPK)
Russia Moscow (MOW)
Russia Nizhny Novgorod (GOJ)
Russia Novosibirsk (OVB)
Russia Rostov-on-Don (ROV)
Russia Ryazan (RZN)
Russia Samara (KUF)
Russia Saratov (GSV)
Russia St. Petersburg (LED)
Russia Tambov (TBW)
Russia Tula (TYA)
Russia Tver (KLD)
Russia Ufa (UFA)
Russia Volgograd (VOG)
Russia Voronezh (VOZ)
Russia Yekaterinburg (SVX)
```