### PR TITLE
Room-server: fixed first message letters trim

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -4462,9 +4462,7 @@ class MeshCoreConnector extends ChangeNotifier {
           } else if (contact?.type == advTypeRoom) {
             _notificationService.showMessageNotification(
               contactName: contact?.name ?? 'Unknown Room',
-              message: message.text.length > 4
-                  ? message.text.substring(4)
-                  : message.text,
+              message: message.text,
               contactId: message.senderKeyHex,
               badgeCount: getTotalUnreadCount(),
             );
@@ -4511,16 +4509,24 @@ class MeshCoreConnector extends ChangeNotifier {
         timestampRaw * 1000,
       );
 
-      if (txtType == 2) {
-        reader.skipBytes(4); // Skip extra 4 bytes for signed/plain variants
+      final flags = txtType;
+      final shiftedType = flags >> 2;
+      final rawType = flags;
+      final isSigned = shiftedType == txtTypeSigned || rawType == txtTypeSigned;
+      final Uint8List? roomAuthorPrefix;
+      if (isSigned) {
+        // Room-server pushed posts use signed/plain contact messages where this
+        // 4-byte "signature" field is actually the original author's pubkey
+        // prefix. Keep it as metadata; the text starts after these bytes.
+        roomAuthorPrefix = reader.readBytes(4);
+      } else {
+        roomAuthorPrefix = null;
       }
 
       final msgText = reader.readCString();
 
-      final flags = txtType;
-      final shiftedType = flags >> 2;
-      final rawType = flags;
-      final isPlain = shiftedType == txtTypePlain || rawType == txtTypePlain;
+      final isPlain =
+          shiftedType == txtTypePlain || rawType == txtTypePlain || isSigned;
       final isCli = shiftedType == txtTypeCliData || rawType == txtTypeCliData;
       if (!isPlain && !isCli) {
         appLogger.warn(
@@ -4557,9 +4563,7 @@ class MeshCoreConnector extends ChangeNotifier {
         status: MessageStatus.delivered,
         pathLength: pathLength == 0xFF ? 0 : pathLength,
         pathBytes: Uint8List(0),
-        fourByteRoomContactKey: msgText.length >= 4
-            ? Uint8List.fromList(msgText.substring(0, 4).codeUnits)
-            : null,
+        fourByteRoomContactKey: roomAuthorPrefix,
       );
     } catch (e) {
       appLogger.warn('Error parsing contact direct message: $e');

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -485,6 +485,8 @@ class _ChatScreenState extends State<ChatScreen> {
           final message = reversedMessages[messageIndex];
           String fourByteHex = '';
           if (contact.type == advTypeRoom) {
+            // Room-server messages carry the original author's 4-byte prefix
+            // separately from message.text; use it only for resolving the name.
             contact = _resolveContactFrom4Bytes(
               connector,
               message.fourByteRoomContactKey.isEmpty
@@ -509,7 +511,6 @@ class _ChatScreenState extends State<ChatScreen> {
                     ? "${contact.name} [$fourByteHex]"
                     : contact.name,
                 sourceId: widget.contact.publicKeyHex,
-                isRoomServer: resolvedContact.type == advTypeRoom,
                 textScale: textScale,
                 onTap: () => _openMessagePath(message, contact),
                 onLongPress: () => _showMessageActions(message, contact),
@@ -1721,7 +1722,6 @@ class _ChatScreenState extends State<ChatScreen> {
 class _MessageBubble extends StatelessWidget {
   final Message message;
   final String senderName;
-  final bool isRoomServer;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
   final void Function(Message message, String emoji)? onRetryReaction;
@@ -1732,7 +1732,6 @@ class _MessageBubble extends StatelessWidget {
     required this.message,
     required this.senderName,
     required this.sourceId,
-    required this.isRoomServer,
     required this.textScale,
     this.onTap,
     this.onLongPress,
@@ -1758,10 +1757,9 @@ class _MessageBubble extends StatelessWidget {
         : (isOutgoing ? colorScheme.onPrimary : colorScheme.onSurface);
     final metaColor = textColor.withValues(alpha: 0.7);
     const bodyFontSize = 14.0;
-    String messageText = message.text;
-    if (isRoomServer && !isOutgoing) {
-      messageText = message.text.substring(4.clamp(0, message.text.length));
-    }
+    // Do not strip room-server author bytes here: the parser stores them in
+    // fourByteRoomContactKey, so message.text is safe to render as-is.
+    final messageText = message.text;
     final translatedDisplayText =
         message.translatedText != null &&
             message.translatedText!.trim().isNotEmpty


### PR DESCRIPTION
On room-servers, the first 4 characters of all incoming messages are truncated. Also, sender names was truncated. With this fix, they are now displayed in full again.

How to reproduce: Go to a room server, receive new messages, and check them.

Next, apply the fix and check again. New messages should now appear in full.

This fix was created using Codex: I took the current implementation in meshcore_open and compared it with the implementations from the firmware and meshcore_py. The fix involves aligning the mechanism with the latter two sources.

<details>
  <summary>Screenshot</summary>
  
  <img width="576" height="436" alt="room-server" src="https://github.com/user-attachments/assets/510f88d1-9999-46b4-b6f8-e44d5571fbe8" />
  
</details>