### PR TITLE
Add Australia (Mid) Radio Preset

### DIFF
--- a/documentation/settings.md
+++ b/documentation/settings.md
@@ -52,7 +52,7 @@ These settings are sent directly to the connected device firmware.
 
 ### Radio Settings
 Opens a dialog pre-populated with the device's current radio settings. Contains:
-- **Preset dropdown**: Regional presets — selecting a preset immediately fills all fields below. Includes presets for Australia, Australia (Narrow), Australia SA WA QLD, Czech Republic, EU 433MHz, EU/UK (Long Range), EU/UK (Medium Range), EU/UK (Narrow), New Zealand, New Zealand (Narrow), Portugal 433, Portugal 869, numerous Russia city presets, Switzerland, USA Arizona, USA/Canada, and Vietnam
+- **Preset dropdown**: Regional presets — selecting a preset immediately fills all fields below. Includes presets for Australia, Australia (Narrow), Australia (Mid), Australia SA WA QLD, Czech Republic, EU 433MHz, EU/UK (Long Range), EU/UK (Medium Range), EU/UK (Narrow), New Zealand, New Zealand (Narrow), Portugal 433, Portugal 869, numerous Russia city presets, Switzerland, USA Arizona, USA/Canada, and Vietnam
 - **Frequency** (MHz): Free text, validated 300–2500 MHz
 - **Bandwidth**: Dropdown (7.8 / 10.4 / 15.6 / 20.8 / 31.25 / 41.7 / 62.5 / 125 / 250 / 500 kHz)
 - **Spreading Factor**: SF5–SF12

--- a/lib/models/radio_settings.dart
+++ b/lib/models/radio_settings.dart
@@ -82,6 +82,16 @@ class RadioSettings {
       ),
     ),
     (
+      'Australia (Mid)',
+      RadioSettings(
+        frequencyMHz: 915.075,
+        bandwidth: LoRaBandwidth.bw125,
+        spreadingFactor: LoRaSpreadingFactor.sf9,
+        codingRate: LoRaCodingRate.cr4_5,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
       'Australia SA, WA, QLD',
       RadioSettings(
         frequencyMHz: 923.125,


### PR DESCRIPTION
This mirrors the config option from the official Meshcore app, and represents the preset now commonly in use in New South Wales.

Being a minor update which mirrors the official app, I have gone straight to PR, but happy to discuss if needed.

For reference, from the Meshcore app:

<img width="378" height="466" alt="image" src="https://github.com/user-attachments/assets/1fe035e5-264b-4a9f-9947-53998d61d751" />

- [x] Docs updated
- [x] `flutter analyze` run
- [x] `dart format` run