### PR TITLE
add High Contrast filter for maps

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -76,8 +76,7 @@ class Cyr2LatProfile {
 
 class AppSettings {
   static const Object _unset = Object();
-  static const String stadiaDemo =
-      '51bd0381-4685-4666-bae8-48940f6d77c0';
+  static const String stadiaDemo = '51bd0381-4685-4666-bae8-48940f6d77c0';
 
   final bool clearPathOnMaxRetry;
   final bool mapShowRepeaters;
@@ -137,8 +136,7 @@ class AppSettings {
     return apiKey;
   }
 
-  bool get usesstadiaDemo =>
-      effectiveMapTileApiKey == stadiaDemo;
+  bool get usesstadiaDemo => effectiveMapTileApiKey == stadiaDemo;
 
   Map<String, String> get cyr2latCharMap {
     final profile = cyr2latProfiles.firstWhere(

--- a/lib/screens/app_settings_screen.dart
+++ b/lib/screens/app_settings_screen.dart
@@ -1153,9 +1153,7 @@ class AppSettingsScreen extends StatelessWidget {
   ) {
     final currentApiKey = settingsService.settings.mapTileApiKey?.trim() ?? '';
     final maskedApiKey = _maskApiKey(
-      currentApiKey.isEmpty
-          ? AppSettings.stadiaDemo
-          : currentApiKey,
+      currentApiKey.isEmpty ? AppSettings.stadiaDemo : currentApiKey,
     );
     final controller = TextEditingController(text: maskedApiKey);
     showDialog(

--- a/lib/screens/channel_chat_screen.dart
+++ b/lib/screens/channel_chat_screen.dart
@@ -700,9 +700,9 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                                   child: Text(
                                     context.l10n.channels_via(
                                       _formatPathPrefixes(
-                                      displayPath,
-                                      displayPathHashWidth,
-                                    ),
+                                        displayPath,
+                                        displayPathHashWidth,
+                                      ),
                                     ),
                                     style: MeshTheme.mono(
                                       fontSize: 9.5 * textScale,
@@ -1214,25 +1214,19 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                           decoration: InputDecoration(
                             hintText: context.l10n.chat_typeMessage,
                             border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                MeshRadii.md,
-                              ),
+                              borderRadius: BorderRadius.circular(MeshRadii.md),
                               borderSide: BorderSide(
                                 color: scheme.outlineVariant,
                               ),
                             ),
                             enabledBorder: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                MeshRadii.md,
-                              ),
+                              borderRadius: BorderRadius.circular(MeshRadii.md),
                               borderSide: BorderSide(
                                 color: scheme.outlineVariant,
                               ),
                             ),
                             focusedBorder: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                MeshRadii.md,
-                              ),
+                              borderRadius: BorderRadius.circular(MeshRadii.md),
                               borderSide: BorderSide(
                                 color: scheme.primary,
                                 width: 1.5,

--- a/lib/screens/channels_screen.dart
+++ b/lib/screens/channels_screen.dart
@@ -412,7 +412,8 @@ class _ChannelsScreenState extends State<ChannelsScreen>
     final messages = connector.getChannelMessages(channel);
     final lastMessage = messages.isNotEmpty ? messages.last : null;
     final lastMessageText = lastMessage?.text ?? '';
-    final lastPreview = lastMessageText.isNotEmpty &&
+    final lastPreview =
+        lastMessageText.isNotEmpty &&
             GifHelper.parseGif(lastMessageText) != null
         ? context.l10n.chat_receivedGif
         : lastMessageText;

--- a/lib/services/map_tile_cache_service.dart
+++ b/lib/services/map_tile_cache_service.dart
@@ -12,12 +12,15 @@ enum MapRasterSourcePreset {
   osmAuto('osm_auto'),
   osmStandard('osm_standard'),
   osmDark('osm_dark'),
+  osmDarkHC('osm_darkHC'),
   stamenTerrain('stamen_terrain'),
   alidadeSmoothDark('alidade_smooth_dark'),
   outdoors('outdoors'),
   osmBright('osm_bright'),
   outdoorsDark('outdoors_dark'),
-  osmBrightDark('osm_bright_dark');
+  outdoorsDarkHC('outdoors_darkHC'),
+  osmBrightDark('osm_bright_dark'),
+  osmBrightDarkHC('osm_bright_darkHC');
 
   const MapRasterSourcePreset(this.id);
 
@@ -101,6 +104,12 @@ class MapRasterSourceCatalog {
     label: 'OpenStreetMap Dark',
     description: 'Standard OpenStreetMap tiles with an inverted dark filter',
   );
+  static const MapRasterSourceDefinition osmDarkHC = MapRasterSourceDefinition(
+    id: 'osm_darkHC',
+    label: 'OpenStreetMap Dark High Contrast',
+    description:
+        'Standard OpenStreetMap tiles with an inverted high contrast dark filter',
+  );
   static const MapRasterSourceDefinition stamenTerrain =
       MapRasterSourceDefinition(
         id: 'stamen_terrain',
@@ -139,11 +148,27 @@ class MapRasterSourceCatalog {
         isStadia: true,
         allowsBulkDownload: true,
       );
+  static const MapRasterSourceDefinition outdoorsDarkHC =
+      MapRasterSourceDefinition(
+        id: 'outdoors',
+        label: 'Outdoors Dark High Contrast',
+        description: 'High contrast dark version of the Outdoors map style',
+        isStadia: true,
+        allowsBulkDownload: true,
+      );
   static const MapRasterSourceDefinition osmBrightDark =
       MapRasterSourceDefinition(
         id: 'osm_bright',
         label: 'OSM Bright Dark',
         description: 'Dark version of the OSM Bright map style',
+        isStadia: true,
+        allowsBulkDownload: true,
+      );
+  static const MapRasterSourceDefinition osmBrightDarkHC =
+      MapRasterSourceDefinition(
+        id: 'osm_bright',
+        label: 'OSM Bright Dark High Contrast',
+        description: 'High contrast dark version of the OSM Bright map style',
         isStadia: true,
         allowsBulkDownload: true,
       );
@@ -156,16 +181,22 @@ class MapRasterSourceCatalog {
         return osmStandard;
       case MapRasterSourcePreset.osmDark:
         return osmDark;
+      case MapRasterSourcePreset.osmDarkHC:
+        return osmDarkHC;
       case MapRasterSourcePreset.alidadeSmoothDark:
         return alidadeSmoothDark;
       case MapRasterSourcePreset.outdoors:
         return outdoors;
       case MapRasterSourcePreset.outdoorsDark:
         return outdoorsDark;
+      case MapRasterSourcePreset.outdoorsDarkHC:
+        return outdoorsDarkHC;
       case MapRasterSourcePreset.osmBright:
         return osmBright;
       case MapRasterSourcePreset.osmBrightDark:
         return osmBrightDark;
+      case MapRasterSourcePreset.osmBrightDarkHC:
+        return osmBrightDarkHC;
       case MapRasterSourcePreset.stamenTerrain:
         return stamenTerrain;
     }
@@ -335,8 +366,11 @@ class MapTileCacheService extends ChangeNotifier {
   ) {
     switch (MapRasterSourcePreset.fromId(settings.mapRasterSourceId)) {
       case MapRasterSourcePreset.osmDark:
+      case MapRasterSourcePreset.osmDarkHC:
       case MapRasterSourcePreset.outdoorsDark:
+      case MapRasterSourcePreset.outdoorsDarkHC:
       case MapRasterSourcePreset.osmBrightDark:
+      case MapRasterSourcePreset.osmBrightDarkHC:
         return true;
       case MapRasterSourcePreset.osmAuto:
         return brightness == Brightness.dark;
@@ -345,6 +379,25 @@ class MapTileCacheService extends ChangeNotifier {
       case MapRasterSourcePreset.alidadeSmoothDark:
       case MapRasterSourcePreset.outdoors:
       case MapRasterSourcePreset.osmBright:
+        return false;
+    }
+  }
+
+  static bool _isHighContrastDarkPreset(MapRasterSourcePreset preset) {
+    switch (preset) {
+      case MapRasterSourcePreset.osmDarkHC:
+      case MapRasterSourcePreset.outdoorsDarkHC:
+      case MapRasterSourcePreset.osmBrightDarkHC:
+        return true;
+      case MapRasterSourcePreset.osmAuto:
+      case MapRasterSourcePreset.osmStandard:
+      case MapRasterSourcePreset.osmDark:
+      case MapRasterSourcePreset.stamenTerrain:
+      case MapRasterSourcePreset.alidadeSmoothDark:
+      case MapRasterSourcePreset.outdoors:
+      case MapRasterSourcePreset.outdoorsDark:
+      case MapRasterSourcePreset.osmBright:
+      case MapRasterSourcePreset.osmBrightDark:
         return false;
     }
   }
@@ -365,6 +418,28 @@ class MapTileCacheService extends ChangeNotifier {
     -0.0397,
     0,
     170,
+    0,
+    0,
+    0,
+    1,
+    0,
+  ]);
+  static const ColorFilter _darkHCMapFilter = ColorFilter.matrix([
+    0.7634200013,
+    -1.9008999332,
+    -0.1915199924,
+    0,
+    338.15,
+    -0.5665799987,
+    -0.5720999709,
+    -0.1915199924,
+    0,
+    338.15,
+    -0.5665799987,
+    -1.9008999332,
+    1.1384799335,
+    0,
+    338.15,
     0,
     0,
     0,
@@ -393,7 +468,13 @@ class MapTileCacheService extends ChangeNotifier {
     );
 
     if (shouldApplyDarkFilter) {
-      layer = ColorFiltered(colorFilter: _darkMapFilter, child: layer);
+      final activePreset = MapRasterSourcePreset.fromId(
+        appSettingsService.settings.mapRasterSourceId,
+      );
+      final filter = _isHighContrastDarkPreset(activePreset)
+          ? _darkHCMapFilter
+          : _darkMapFilter;
+      layer = ColorFiltered(colorFilter: filter, child: layer);
     }
 
     if (opacity < 1) {

--- a/test/models/model_changes_test.dart
+++ b/test/models/model_changes_test.dart
@@ -643,7 +643,6 @@ void main() {
         expect(contacts.first.path, equals(Uint8List.fromList([0x11, 0x22])));
       },
     );
-
   });
 
   group('AppSettingsService — gps interval fallback', () {

--- a/test/screens/path_trace_test.dart
+++ b/test/screens/path_trace_test.dart
@@ -71,13 +71,15 @@ Widget _buildTestApp({
   required MeshCoreConnector connector,
   required Widget child,
 }) {
+  final appSettingsService = AppSettingsService();
+
   return MultiProvider(
     providers: [
       ChangeNotifierProvider<MeshCoreConnector>.value(value: connector),
-      ChangeNotifierProvider<AppSettingsService>(
-        create: (_) => AppSettingsService(),
+      ChangeNotifierProvider<AppSettingsService>.value(value: appSettingsService),
+      ChangeNotifierProvider<MapTileCacheService>(
+        create: (_) => MapTileCacheService(appSettingsService: appSettingsService),
       ),
-      Provider<MapTileCacheService>(create: (_) => MapTileCacheService()),
       ChangeNotifierProvider<PathHistoryService>(
         create: (_) => PathHistoryService(_FakeStorageService()),
       ),

--- a/test/screens/path_trace_test.dart
+++ b/test/screens/path_trace_test.dart
@@ -22,7 +22,8 @@ class _FakeStorageService extends StorageService {
     ContactPathHistory history,
   ) async {}
   @override
-  Future<ContactPathHistory?> loadPathHistory(String contactPubKeyHex) async => null;
+  Future<ContactPathHistory?> loadPathHistory(String contactPubKeyHex) async =>
+      null;
   @override
   Future<void> clearPathHistory(String contactPubKeyHex) async {}
 }
@@ -76,9 +77,12 @@ Widget _buildTestApp({
   return MultiProvider(
     providers: [
       ChangeNotifierProvider<MeshCoreConnector>.value(value: connector),
-      ChangeNotifierProvider<AppSettingsService>.value(value: appSettingsService),
+      ChangeNotifierProvider<AppSettingsService>.value(
+        value: appSettingsService,
+      ),
       ChangeNotifierProvider<MapTileCacheService>(
-        create: (_) => MapTileCacheService(appSettingsService: appSettingsService),
+        create: (_) =>
+            MapTileCacheService(appSettingsService: appSettingsService),
       ),
       ChangeNotifierProvider<PathHistoryService>(
         create: (_) => PathHistoryService(_FakeStorageService()),


### PR DESCRIPTION
Addition to the merged  #461 [Alternative Maps](https://github.com/zjs81/meshcore-open/pull/461). The Issue #495 [Accessibility: low contrast on dark map](https://github.com/zjs81/meshcore-open/pull/461) was raised.

I had a filter with more contrast, but in the theme overhaul someone else implemented another filter.
The merged map filter was lower in contrast, but more consistent with the theme of the app. 

Now I added my first filter with higher Contrast as "Dark High Contrast" maps..