### PR TITLE
Add self node telemetry screen

### DIFF
--- a/lib/screens/companion_radio_stats_screen.dart
+++ b/lib/screens/companion_radio_stats_screen.dart
@@ -1,6 +1,11 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:meshcore_open/connector/meshcore_connector.dart';
+import 'package:meshcore_open/connector/meshcore_protocol.dart';
 import 'package:meshcore_open/models/companion_radio_stats.dart';
+import 'package:meshcore_open/models/contact.dart';
+import 'package:meshcore_open/screens/telemetry_screen.dart';
 import 'package:meshcore_open/l10n/l10n.dart';
 import 'package:meshcore_open/theme/mesh_theme.dart';
 import 'package:meshcore_open/widgets/mesh_ui.dart';
@@ -77,6 +82,35 @@ class _CompanionRadioStatsScreenState extends State<CompanionRadioStatsScreen> {
       appBar: AppBar(
         title: Text(l10n.radioStats_screenTitle),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.thermostat),
+            tooltip: l10n.contact_telemetry,
+            onPressed: () {
+              final connector = Provider.of<MeshCoreConnector>(
+                context,
+                listen: false,
+              );
+              final selfKey = connector.selfPublicKey;
+              if (selfKey == null || selfKey.isEmpty) return;
+              final selfContact = Contact(
+                publicKey: selfKey,
+                name: connector.selfName ?? '',
+                type: advTypeChat,
+                pathLength: 0,
+                path: Uint8List(0),
+                lastSeen: DateTime.now(),
+              );
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) =>
+                      TelemetryScreen(contact: selfContact, isSelf: true),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Selector<MeshCoreConnector, ({bool connected, bool supported})>(
         selector: (_, c) => (

--- a/lib/screens/companion_radio_stats_screen.dart
+++ b/lib/screens/companion_radio_stats_screen.dart
@@ -1,10 +1,6 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:meshcore_open/connector/meshcore_connector.dart';
-import 'package:meshcore_open/connector/meshcore_protocol.dart';
 import 'package:meshcore_open/models/companion_radio_stats.dart';
-import 'package:meshcore_open/models/contact.dart';
 import 'package:meshcore_open/screens/telemetry_screen.dart';
 import 'package:meshcore_open/l10n/l10n.dart';
 import 'package:meshcore_open/theme/mesh_theme.dart';
@@ -86,29 +82,7 @@ class _CompanionRadioStatsScreenState extends State<CompanionRadioStatsScreen> {
           IconButton(
             icon: const Icon(Icons.thermostat),
             tooltip: l10n.contact_telemetry,
-            onPressed: () {
-              final connector = Provider.of<MeshCoreConnector>(
-                context,
-                listen: false,
-              );
-              final selfKey = connector.selfPublicKey;
-              if (selfKey == null || selfKey.isEmpty) return;
-              final selfContact = Contact(
-                publicKey: selfKey,
-                name: connector.selfName ?? '',
-                type: advTypeChat,
-                pathLength: 0,
-                path: Uint8List(0),
-                lastSeen: DateTime.now(),
-              );
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) =>
-                      TelemetryScreen(contact: selfContact, isSelf: true),
-                ),
-              );
-            },
+            onPressed: () => pushSelfTelemetryScreen(context),
           ),
         ],
       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -19,6 +19,7 @@ import 'app_settings_screen.dart';
 import 'app_debug_log_screen.dart';
 import 'ble_debug_log_screen.dart';
 import '../widgets/radio_stats_entry.dart';
+import 'telemetry_screen.dart';
 import '../widgets/sync_progress_overlay.dart';
 import 'region_management_screen.dart';
 
@@ -466,6 +467,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
           subtitle: l10n.radioStats_settingsSubtitle,
           onTap: connector.isConnected && connector.supportsCompanionRadioStats
               ? () => pushCompanionRadioStatsScreen(context)
+              : null,
+        ),
+        const Divider(height: 1, indent: 16),
+        _tappableTile(
+          context,
+          icon: Icons.thermostat_outlined,
+          title: l10n.contact_telemetry,
+          subtitle: l10n.repeater_telemetrySubtitle,
+          onTap: connector.isConnected
+              ? () => pushSelfTelemetryScreen(context)
               : null,
         ),
         const Divider(height: 1, indent: 16),

--- a/lib/screens/telemetry_screen.dart
+++ b/lib/screens/telemetry_screen.dart
@@ -22,11 +22,36 @@ import '../widgets/telemetry_location_map.dart';
 import '../theme/mesh_theme.dart';
 import '../widgets/mesh_ui.dart';
 
+/// Opens the telemetry screen for the locally connected node.
+void pushSelfTelemetryScreen(BuildContext context) {
+  final connector = Provider.of<MeshCoreConnector>(context, listen: false);
+  final selfKey = connector.selfPublicKey;
+  if (selfKey == null || selfKey.isEmpty) return;
+  final selfContact = Contact(
+    publicKey: selfKey,
+    name: connector.selfName ?? '',
+    type: advTypeChat,
+    pathLength: 0,
+    path: Uint8List(0),
+    lastSeen: DateTime.now(),
+  );
+  Navigator.push(
+    context,
+    MaterialPageRoute<void>(
+      builder: (context) => TelemetryScreen(contact: selfContact, isSelf: true),
+    ),
+  );
+}
+
 class TelemetryScreen extends StatefulWidget {
   final Contact contact;
   final bool isSelf;
 
-  const TelemetryScreen({super.key, required this.contact, this.isSelf = false});
+  const TelemetryScreen({
+    super.key,
+    required this.contact,
+    this.isSelf = false,
+  });
 
   @override
   State<TelemetryScreen> createState() => _TelemetryScreenState();
@@ -526,7 +551,7 @@ class _TelemetryScreenState extends State<TelemetryScreen> {
           _temperatureText(value, isImperialUnits),
         );
       case 'humidity':
-        return _TelemetryFieldDisplay(l10n.telemetry_humidityLabel, text);
+        return _TelemetryFieldDisplay(l10n.telemetry_humidityLabel, '$text%');
       case 'accelerometer':
         return _TelemetryFieldDisplay(
           l10n.telemetry_accelerometerLabel,

--- a/lib/screens/telemetry_screen.dart
+++ b/lib/screens/telemetry_screen.dart
@@ -24,8 +24,9 @@ import '../widgets/mesh_ui.dart';
 
 class TelemetryScreen extends StatefulWidget {
   final Contact contact;
+  final bool isSelf;
 
-  const TelemetryScreen({super.key, required this.contact});
+  const TelemetryScreen({super.key, required this.contact, this.isSelf = false});
 
   @override
   State<TelemetryScreen> createState() => _TelemetryScreenState();
@@ -158,7 +159,7 @@ class _TelemetryScreenState extends State<TelemetryScreen> {
   void _handleTelemetryResponse(Uint8List frame) {
     final parsedTelemetry = CayenneLpp.parseByChannel(frame);
     final batteryMv = _extractTelemetryBatteryMillivolts(parsedTelemetry);
-    if (batteryMv != null) {
+    if (batteryMv != null && !widget.isSelf) {
       final connector = Provider.of<MeshCoreConnector>(context, listen: false);
       connector.updateRepeaterBatterySnapshot(
         widget.contact.publicKeyHex,
@@ -204,18 +205,47 @@ class _TelemetryScreenState extends State<TelemetryScreen> {
     });
     try {
       final connector = Provider.of<MeshCoreConnector>(context, listen: false);
-      final selection = await connector.preparePathForContactSend(
-        _resolveContact(connector),
-      );
-      _pendingStatusSelection = selection;
       Uint8List frame;
-      if (widget.contact.type != advTypeChat) {
-        frame = buildSendBinaryReq(
-          widget.contact.publicKey,
-          payload: buildTelemetryBinaryPayload(),
-        );
+      if (widget.isSelf) {
+        // ask the connected node for its own telemetry, no mesh path involved
+        frame = buildSendTelemetryReq(null);
+        final isAutoRefreshRequest = _activeTelemetryRequestIsAutoRefresh;
+        _statusTimeout?.cancel();
+        _statusTimeout = Timer(const Duration(seconds: 5), () {
+          if (!mounted) return;
+          setState(() {
+            _isLoading = false;
+            _isLoaded = false;
+            if (isAutoRefreshRequest && _isAutoRefreshEnabled) {
+              _autoRefreshLastAttemptFailed = true;
+            }
+            _activeTelemetryRequestIsAutoRefresh = false;
+          });
+          if (!isAutoRefreshRequest) {
+            showDismissibleSnackBar(
+              context,
+              content: Text(context.l10n.telemetry_requestTimeout),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            );
+          }
+          if (isAutoRefreshRequest && _isAutoRefreshEnabled) {
+            _scheduleNextAutoRefreshAttempt();
+          }
+          _recordTelemetryResult(false);
+        });
       } else {
-        frame = buildSendTelemetryReq(widget.contact.publicKey);
+        final selection = await connector.preparePathForContactSend(
+          _resolveContact(connector),
+        );
+        _pendingStatusSelection = selection;
+        if (widget.contact.type != advTypeChat) {
+          frame = buildSendBinaryReq(
+            widget.contact.publicKey,
+            payload: buildTelemetryBinaryPayload(),
+          );
+        } else {
+          frame = buildSendTelemetryReq(widget.contact.publicKey);
+        }
       }
       await connector.sendFrame(frame);
     } catch (e) {
@@ -353,12 +383,13 @@ class _TelemetryScreenState extends State<TelemetryScreen> {
         centerTitle: true,
         bottom: const SyncProgressAppBarBottom(),
         actions: [
-          IconButton(
-            icon: Icon(isFloodMode ? Icons.waves : Icons.route),
-            tooltip: l10n.repeater_routingMode,
-            onPressed: () =>
-                ContactRoutingSheet.show(context, contact: widget.contact),
-          ),
+          if (!widget.isSelf)
+            IconButton(
+              icon: Icon(isFloodMode ? Icons.waves : Icons.route),
+              tooltip: l10n.repeater_routingMode,
+              onPressed: () =>
+                  ContactRoutingSheet.show(context, contact: widget.contact),
+            ),
           IconButton(
             icon: _isLoading
                 ? const SizedBox(


### PR DESCRIPTION
## Summary

Adds a telemetry view for the locally connected node. The firmware answers self telemetry requests over the companion protocol (the 4 byte CMD_SEND_TELEMETRY_REQ form) with full permissions, but the app previously had no way to show it. This reuses the existing TelemetryScreen with an isSelf mode:

- Sends the self request instead of routing over the mesh, with a 5 second timeout since there is no sent confirmation for local requests
- Response matching works through a synthesized contact carrying the self public key
- Hides the routing mode button (meaningless for the local node) and skips the repeater battery snapshot cache
- Auto refresh works as it does for contacts

Entry points: a new Telemetry tile on the Settings screen (below Radio Stats, disabled when disconnected) and a thermostat icon on the Radio Stats app bar. Also shows humidity values with a percent sign, which applies to contact telemetry too.

No new localization keys, everything reuses existing strings.

## Testing

The self telemetry screen itself is hardware tested on Android (CI built APK) with a RAK4631 BLE companion running current MeshCore dev firmware with an SHTC3 sensor: battery voltage, MCU temperature, sensor temperature and humidity all displayed. The humidity percent formatting and the settings tile from the second commit are compile verified on all five platform targets in CI (analyze and format gates included) and running installed on a test device.
