### PR TITLE
Show connected node hardware and firmware in device info

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -271,6 +271,8 @@ class MeshCoreConnector extends ChangeNotifier {
   bool _batteryRequested = false;
   bool _awaitingSelfInfo = false;
   bool _hasReceivedDeviceInfo = false;
+  String? _manufacturerName;
+  String? _firmwareVersionString;
   // Initial sync is serialized for predictable progress. Firmware exposes one
   // FIFO queued-message stream, so direct/room frames are buffered until after
   // contacts are known.
@@ -459,6 +461,8 @@ class MeshCoreConnector extends ChangeNotifier {
   Uint8List? get selfPublicKey => _selfPublicKey;
   String get selfPublicKeyHex => pubKeyToHex(_selfPublicKey ?? Uint8List(0));
   String? get selfName => _selfName;
+  String? get manufacturerName => _manufacturerName;
+  String? get firmwareVersionString => _firmwareVersionString;
   double? get selfLatitude => _selfLatitude;
   double? get selfLongitude => _selfLongitude;
   List<DirectRepeater> get directRepeaters => _directRepeaters;
@@ -4459,6 +4463,20 @@ class MeshCoreConnector extends ChangeNotifier {
       _hasReceivedDeviceInfo = true;
     }
     _firmwareVerCode = frame[1];
+
+    // Manufacturer/model name (bytes 20..59) and firmware version (60..79)
+    String? readCString(int start, int maxLen) {
+      if (frame.length < start + maxLen) return null;
+      final bytes = frame.sublist(start, start + maxLen);
+      final end = bytes.indexOf(0);
+      final s = String.fromCharCodes(
+        end >= 0 ? bytes.sublist(0, end) : bytes,
+      ).trim();
+      return s.isEmpty ? null : s;
+    }
+
+    _manufacturerName = readCString(20, 40);
+    _firmwareVersionString = readCString(60, 20);
 
     // Parse client_repeat from firmware v9+ (byte 80)
     if (frame.length >= 81) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -248,6 +248,8 @@
   "settings_infoPublicKey": "Public Key",
   "settings_infoContactsCount": "Contacts Count",
   "settings_infoChannelCount": "Channel Count",
+  "settings_infoHardware": "Hardware",
+  "settings_infoFirmware": "Firmware",
   "settings_presets": "Presets",
   "settings_frequency": "Frequency (MHz)",
   "settings_frequencyHelper": "300.0 - 2500.0",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1240,6 +1240,18 @@ abstract class AppLocalizations {
   /// **'Channel Count'**
   String get settings_infoChannelCount;
 
+  /// No description provided for @settings_infoHardware.
+  ///
+  /// In en, this message translates to:
+  /// **'Hardware'**
+  String get settings_infoHardware;
+
+  /// No description provided for @settings_infoFirmware.
+  ///
+  /// In en, this message translates to:
+  /// **'Firmware'**
+  String get settings_infoFirmware;
+
   /// No description provided for @settings_presets.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -627,6 +627,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settings_infoChannelCount => 'Брой канали';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Предварителни настройки';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -624,6 +624,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_infoChannelCount => 'Kanäle';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Voreinstellungen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -612,6 +612,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_infoChannelCount => 'Channel Count';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Presets';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -623,6 +623,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_infoChannelCount => 'Número de canales';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Preajustes';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -627,6 +627,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_infoChannelCount => 'Nombre de canaux';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Préréglages';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -620,6 +620,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_infoChannelCount => 'Csatornaszám';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Előbeállítások';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -625,6 +625,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_infoChannelCount => 'Numero di canali';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Preset';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -595,6 +595,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_infoChannelCount => 'チャンネル数';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'プリセット';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -596,6 +596,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_infoChannelCount => '채널 수';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => '프리셋';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -619,6 +619,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_infoChannelCount => 'Aantal Kanalen';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Voorgeprogrammeerde instellingen';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -627,6 +627,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settings_infoChannelCount => 'Liczba kanałów';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Presety';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -625,6 +625,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_infoChannelCount => 'Número do Canal';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Configurações pré-definidas';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -624,6 +624,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_infoChannelCount => 'Количество каналов';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Пресеты';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -619,6 +619,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settings_infoChannelCount => 'Počet kanálov';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Prednastavenia';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -617,6 +617,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get settings_infoChannelCount => 'Število kanalov';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Prednastavitve';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -614,6 +614,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settings_infoChannelCount => 'Kanalantal';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Fördefinierade inställningar';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -622,6 +622,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settings_infoChannelCount => 'Кількість каналів';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => 'Попередні налаштування';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -588,6 +588,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_infoChannelCount => '频道数量';
 
   @override
+  String get settings_infoHardware => 'Hardware';
+
+  @override
+  String get settings_infoFirmware => 'Firmware';
+
+  @override
   String get settings_presets => '预设';
 
   @override

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -280,6 +280,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         value: connector.deviceIdLabel,
                       ),
                       _buildBatteryInfoRow(context, connector),
+                      if (connector.manufacturerName != null)
+                        _infoRow(
+                          context,
+                          label: l10n.settings_infoHardware,
+                          value: connector.manufacturerName!,
+                        ),
+                      if (connector.firmwareVersionString != null)
+                        _infoRow(
+                          context,
+                          label: l10n.settings_infoFirmware,
+                          value: connector.firmwareVersionString!,
+                        ),
                       if (connector.selfName != null)
                         _infoRow(
                           context,


### PR DESCRIPTION
## Summary

The DEVICE_INFO response from the firmware includes the board manufacturer name (bytes 20 to 59) and the firmware version string (bytes 60 to 79), but the connector skipped both fields. This parses them and shows two new rows, Hardware and Firmware, in the expandable Device Info card on the Settings screen, so you can see what hardware and firmware the connected node runs (the same way Meshtastic surfaces its hw_model, but for the local node using data MeshCore already sends).

Adds two localization keys (settings_infoHardware, settings_infoFirmware) with English fallback in the generated files, following the template arb.

## Testing

Compile verified on all five platform targets in CI, and the parsing follows the firmware frame layout (manufacturer at bytes 20 to 59, version string at 60 to 79, both already sent by the firmware today). Analyze and format gates pass in CI, and the build is running installed on a test device against a RAK4631 companion.
