### PR TITLE
Fix path trace test and restore CI checks

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -76,8 +76,7 @@ class Cyr2LatProfile {
 
 class AppSettings {
   static const Object _unset = Object();
-  static const String stadiaDemo =
-      '51bd0381-4685-4666-bae8-48940f6d77c0';
+  static const String stadiaDemo = '51bd0381-4685-4666-bae8-48940f6d77c0';
 
   final bool clearPathOnMaxRetry;
   final bool mapShowRepeaters;
@@ -137,8 +136,7 @@ class AppSettings {
     return apiKey;
   }
 
-  bool get usesstadiaDemo =>
-      effectiveMapTileApiKey == stadiaDemo;
+  bool get usesstadiaDemo => effectiveMapTileApiKey == stadiaDemo;
 
   Map<String, String> get cyr2latCharMap {
     final profile = cyr2latProfiles.firstWhere(

--- a/lib/screens/app_settings_screen.dart
+++ b/lib/screens/app_settings_screen.dart
@@ -1153,9 +1153,7 @@ class AppSettingsScreen extends StatelessWidget {
   ) {
     final currentApiKey = settingsService.settings.mapTileApiKey?.trim() ?? '';
     final maskedApiKey = _maskApiKey(
-      currentApiKey.isEmpty
-          ? AppSettings.stadiaDemo
-          : currentApiKey,
+      currentApiKey.isEmpty ? AppSettings.stadiaDemo : currentApiKey,
     );
     final controller = TextEditingController(text: maskedApiKey);
     showDialog(

--- a/lib/screens/channel_chat_screen.dart
+++ b/lib/screens/channel_chat_screen.dart
@@ -700,9 +700,9 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                                   child: Text(
                                     context.l10n.channels_via(
                                       _formatPathPrefixes(
-                                      displayPath,
-                                      displayPathHashWidth,
-                                    ),
+                                        displayPath,
+                                        displayPathHashWidth,
+                                      ),
                                     ),
                                     style: MeshTheme.mono(
                                       fontSize: 9.5 * textScale,
@@ -1214,25 +1214,19 @@ class _ChannelChatScreenState extends State<ChannelChatScreen> {
                           decoration: InputDecoration(
                             hintText: context.l10n.chat_typeMessage,
                             border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                MeshRadii.md,
-                              ),
+                              borderRadius: BorderRadius.circular(MeshRadii.md),
                               borderSide: BorderSide(
                                 color: scheme.outlineVariant,
                               ),
                             ),
                             enabledBorder: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                MeshRadii.md,
-                              ),
+                              borderRadius: BorderRadius.circular(MeshRadii.md),
                               borderSide: BorderSide(
                                 color: scheme.outlineVariant,
                               ),
                             ),
                             focusedBorder: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                MeshRadii.md,
-                              ),
+                              borderRadius: BorderRadius.circular(MeshRadii.md),
                               borderSide: BorderSide(
                                 color: scheme.primary,
                                 width: 1.5,

--- a/lib/screens/channels_screen.dart
+++ b/lib/screens/channels_screen.dart
@@ -412,7 +412,8 @@ class _ChannelsScreenState extends State<ChannelsScreen>
     final messages = connector.getChannelMessages(channel);
     final lastMessage = messages.isNotEmpty ? messages.last : null;
     final lastMessageText = lastMessage?.text ?? '';
-    final lastPreview = lastMessageText.isNotEmpty &&
+    final lastPreview =
+        lastMessageText.isNotEmpty &&
             GifHelper.parseGif(lastMessageText) != null
         ? context.l10n.chat_receivedGif
         : lastMessageText;

--- a/test/models/model_changes_test.dart
+++ b/test/models/model_changes_test.dart
@@ -643,7 +643,6 @@ void main() {
         expect(contacts.first.path, equals(Uint8List.fromList([0x11, 0x22])));
       },
     );
-
   });
 
   group('AppSettingsService — gps interval fallback', () {

--- a/test/screens/path_trace_test.dart
+++ b/test/screens/path_trace_test.dart
@@ -22,7 +22,8 @@ class _FakeStorageService extends StorageService {
     ContactPathHistory history,
   ) async {}
   @override
-  Future<ContactPathHistory?> loadPathHistory(String contactPubKeyHex) async => null;
+  Future<ContactPathHistory?> loadPathHistory(String contactPubKeyHex) async =>
+      null;
   @override
   Future<void> clearPathHistory(String contactPubKeyHex) async {}
 }
@@ -77,7 +78,11 @@ Widget _buildTestApp({
       ChangeNotifierProvider<AppSettingsService>(
         create: (_) => AppSettingsService(),
       ),
-      Provider<MapTileCacheService>(create: (_) => MapTileCacheService()),
+      Provider<MapTileCacheService>(
+        create: (context) => MapTileCacheService(
+          appSettingsService: context.read<AppSettingsService>(),
+        ),
+      ),
       ChangeNotifierProvider<PathHistoryService>(
         create: (_) => PathHistoryService(_FakeStorageService()),
       ),


### PR DESCRIPTION
## Summary

CI on dev is currently red: `flutter analyze --fatal-infos --fatal-warnings` fails because `MapTileCacheService` gained a required `appSettingsService` constructor parameter and `test/screens/path_trace_test.dart` still constructs it with no arguments. This wires the test's provider the same way `main.dart` does.

Since analyze fails before the formatting step ever runs, some format drift had also accumulated unnoticed. This includes a `dart format` pass over `lib` and `test` so both gates come back green.

## Testing

Validated on a fork run with the same gates this repo uses: full `flutter analyze --fatal-infos --fatal-warnings` and `dart format --set-exit-if-changed` both pass, and all five platform builds succeed.
