### PR TITLE
Warn when the node reports contact storage is full

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -271,6 +271,7 @@ class MeshCoreConnector extends ChangeNotifier {
   bool _batteryRequested = false;
   bool _awaitingSelfInfo = false;
   bool _hasReceivedDeviceInfo = false;
+  bool _contactsFull = false;
   // Initial sync is serialized for predictable progress. Firmware exposes one
   // FIFO queued-message stream, so direct/room frames are buffered until after
   // contacts are known.
@@ -459,6 +460,7 @@ class MeshCoreConnector extends ChangeNotifier {
   Uint8List? get selfPublicKey => _selfPublicKey;
   String get selfPublicKeyHex => pubKeyToHex(_selfPublicKey ?? Uint8List(0));
   String? get selfName => _selfName;
+  bool get contactsFull => _contactsFull;
   double? get selfLatitude => _selfLatitude;
   double? get selfLongitude => _selfLongitude;
   List<DirectRepeater> get directRepeaters => _directRepeaters;
@@ -2290,6 +2292,7 @@ class MeshCoreConnector extends ChangeNotifier {
       _setState(MeshCoreConnectionState.connected);
       if (_shouldGateInitialChannelSync) {
         _hasReceivedDeviceInfo = false;
+        _contactsFull = false;
         _pendingInitialChannelSync = true;
       }
       await _startBleInitialSync();
@@ -2581,6 +2584,7 @@ class MeshCoreConnector extends ChangeNotifier {
     _selfInfoRetryTimer?.cancel();
     _selfInfoRetryTimer = null;
     _hasReceivedDeviceInfo = false;
+    _contactsFull = false;
     _resetSyncProgressState();
     _bleInitialSyncStarted = false;
     _pathHashByteWidth = 1;
@@ -2752,6 +2756,7 @@ class MeshCoreConnector extends ChangeNotifier {
     _batteryRequested = false;
     _awaitingSelfInfo = false;
     _hasReceivedDeviceInfo = false;
+    _contactsFull = false;
     _maxContacts = _defaultMaxContacts;
     _maxChannels = _defaultMaxChannels;
     _resetSyncProgressState();
@@ -4183,6 +4188,11 @@ class MeshCoreConnector extends ChangeNotifier {
       case pushCodeAdvert:
         // Known contact was seen again - just a pub key, no action needed
         break;
+      case pushCodeContactsFull:
+        debugPrint('Got CONTACTS_FULL');
+        _contactsFull = true;
+        notifyListeners();
+        break;
       case pushCodeNewAdvert:
         debugPrint('Got New CONTACT');
         // It's the same format as respCodeContact, so we can reuse the handler
@@ -4195,6 +4205,9 @@ class MeshCoreConnector extends ChangeNotifier {
       case respCodeEndOfContacts:
         debugPrint('Got END_OF_CONTACTS');
         _isLoadingContacts = false;
+        if (_contactsFull && _contacts.length < _maxContacts) {
+          _contactsFull = false; // capacity freed up since the warning
+        }
         _hasLoadedContacts = true;
         _preserveContactsOnRefresh = false;
         _contactSyncUsesSinceFilter = false;
@@ -6559,6 +6572,7 @@ class MeshCoreConnector extends ChangeNotifier {
     // Preserve deviceId and displayName for UI display during reconnection
     // They're only cleared on manual disconnect via disconnect() method
     _hasReceivedDeviceInfo = false;
+    _contactsFull = false;
     _maxContacts = _defaultMaxContacts;
     _maxChannels = _defaultMaxChannels;
     _resetSyncProgressState();

--- a/lib/connector/meshcore_protocol.dart
+++ b/lib/connector/meshcore_protocol.dart
@@ -282,6 +282,7 @@ const int pushCodeNewAdvert = 0x8A;
 const int pushCodeTelemetryResponse = 0x8B;
 const int pushCodeBinaryResponse = 0x8C;
 const int pushCodeControlData = 0x8E;
+const int pushCodeContactsFull = 0x90;
 
 // Contact/advertisement types
 const int advTypeChat = 1;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -463,6 +463,7 @@
   },
   "contacts_noUnreadContacts": "No unread contacts",
   "contacts_noContactsFound": "No contacts or groups found",
+  "contacts_storageFull": "Contact storage on the node is full. New nodes cannot be added until contacts are removed.",
   "contacts_deleteContact": "Delete Contact",
   "contacts_removeConfirm": "Remove {contactName} from contacts?",
   "@contacts_removeConfirm": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2002,6 +2002,12 @@ abstract class AppLocalizations {
   /// **'No contacts or groups found'**
   String get contacts_noContactsFound;
 
+  /// No description provided for @contacts_storageFull.
+  ///
+  /// In en, this message translates to:
+  /// **'Contact storage on the node is full. New nodes cannot be added until contacts are removed.'**
+  String get contacts_storageFull;
+
   /// No description provided for @contacts_deleteContact.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1068,6 +1068,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get contacts_noContactsFound => 'Няма намерени контакти или групи.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Изтрий Контакт';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1065,6 +1065,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Keine Kontakte oder Gruppen gefunden.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Kontakt löschen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1046,6 +1046,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get contacts_noContactsFound => 'No contacts or groups found';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Delete Contact';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1062,6 +1062,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se encontraron contactos ni grupos.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Eliminar contacto';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1066,6 +1066,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get contacts_noContactsFound => 'Aucun contact ou groupe trouvé.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Supprimer le contact';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1058,6 +1058,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get contacts_noContactsFound => 'Nem található névjegy vagy csoport';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Névjegy törlése';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1064,6 +1064,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get contacts_noContactsFound => 'Nessun contatto o gruppo trovato.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Elimina Contatto';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1007,6 +1007,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get contacts_noContactsFound => '連絡先またはグループは見つかりませんでした。';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => '連絡先を削除';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1010,6 +1010,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get contacts_noContactsFound => '연락처 또는 그룹이 검색되지 않았습니다.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => '연락처 삭제';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1056,6 +1056,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get contacts_noContactsFound => 'Geen contacten of groepen gevonden.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Verwijder Contact';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1074,6 +1074,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Brak znalezionych kontaktów ani grup.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Usuń Kontakt';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1064,6 +1064,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Não foram encontrados contatos ou grupos.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Excluir Contato';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1065,6 +1065,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get contacts_noContactsFound => 'Контакты или группы не найдены';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Удалить контакт';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1053,6 +1053,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Neboli nájdených žiadnych kontaktov ani skupiny.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Odstrániť kontakt';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1053,6 +1053,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get contacts_noContactsFound => 'Stiki niso najdeni.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Izbriši stik';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1047,6 +1047,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Inga kontakter eller grupper hittades.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Ta bort Kontakt';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1060,6 +1060,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get contacts_noContactsFound => 'Контактів або груп не знайдено.';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => 'Видалити контакт';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -993,6 +993,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get contacts_noContactsFound => '未找到任何联系人或群聊';
 
   @override
+  String get contacts_storageFull =>
+      'Contact storage on the node is full. New nodes cannot be added until contacts are removed.';
+
+  @override
   String get contacts_deleteContact => '删除联系人';
 
   @override

--- a/lib/screens/contacts_screen.dart
+++ b/lib/screens/contacts_screen.dart
@@ -882,6 +882,31 @@ class _ContactsScreenState extends State<ContactsScreen>
             ],
           ),
         ),
+        if (connector.contactsFull)
+          Container(
+            width: double.infinity,
+            color: Theme.of(context).colorScheme.errorContainer,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.warning_amber_rounded,
+                  size: 18,
+                  color: Theme.of(context).colorScheme.onErrorContainer,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    context.l10n.contacts_storageFull,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: Theme.of(context).colorScheme.onErrorContainer,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
         Expanded(
           child: RefreshIndicator(
             onRefresh: () => connector.getContacts(),


### PR DESCRIPTION
## Summary

The firmware pushes PUSH_CODE_CONTACTS_FULL (0x90) when the node's contact storage fills up, but the app ignored it, so on a busy mesh new nodes silently stop appearing with no explanation. This handles the push and shows a warning banner at the top of the contacts list. The flag clears on disconnect and automatically once a contact sync shows capacity has been freed.

One new localization key (contacts_storageFull) added through the template arb with English fallback in the generated files.

## Testing

Verified end to end on hardware. A RAK4631 companion was flashed with a local test build that calls onContactsFull() on a timer, so the firmware emits the real PUSH_CODE_CONTACTS_FULL frame, and the banner appeared on the contacts screen as expected. Normal operation with a healthy contact table shows no banner. Also compile verified on all five platform targets in CI with the analyze and format gates passing.
