### PR TITLE
Add high voltage LiPo battery chemistry option

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -343,6 +343,7 @@
   "appSettings_batteryNmc": "18650 NMC (3.0-4.2V)",
   "appSettings_batteryLifepo4": "LiFePO4 (2.6-3.65V)",
   "appSettings_batteryLipo": "LiPo (3.0-4.2V)",
+  "appSettings_batteryLipoHv": "LiPo HV (3.0-4.35V)",
   "appSettings_mapDisplay": "Map Display",
   "appSettings_showRepeaters": "Show Repeaters",
   "appSettings_showRepeatersSubtitle": "Display repeater nodes on the map",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1726,6 +1726,12 @@ abstract class AppLocalizations {
   /// **'LiPo (3.0-4.2V)'**
   String get appSettings_batteryLipo;
 
+  /// No description provided for @appSettings_batteryLipoHv.
+  ///
+  /// In en, this message translates to:
+  /// **'LiPo HV (3.0-4.35V)'**
+  String get appSettings_batteryLipoHv;
+
   /// No description provided for @appSettings_mapDisplay.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -903,6 +903,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appSettings_batteryLipo => 'Литиев полимер (3.0-4.2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Карта за показване';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -900,6 +900,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0–4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Kartendarstellung';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -883,6 +883,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3.0-4.2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Map Display';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -897,6 +897,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2 V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Visualización del mapa';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -901,6 +901,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Affichage de la carte';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -892,6 +892,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2 V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Térkép megjelenítése';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -900,6 +900,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Visualizzazione Mappa';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -851,6 +851,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3.0-4.2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => '地図表示';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -854,6 +854,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get appSettings_batteryLipo => '리튬 폴리머 (3.0-4.2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => '지도 표시';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -892,6 +892,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Kaartweergave';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -902,6 +902,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Wyświetlanie mapy';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -899,6 +899,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Exibição do Mapa';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -901,6 +901,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3.0–4.2 В)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Отображение карты';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -888,6 +888,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Zobrazenie mapy';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -890,6 +890,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Prikaz zemljevida';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -883,6 +883,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3,0-4,2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Kartvisning';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -895,6 +895,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get appSettings_batteryLipo => 'LiPo (3.0-4.2В)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => 'Відображення карти';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -838,6 +838,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get appSettings_batteryLipo => '锂聚合物电池 (3.0-4.2V)';
 
   @override
+  String get appSettings_batteryLipoHv => 'LiPo HV (3.0-4.35V)';
+
+  @override
   String get appSettings_mapDisplay => '地图显示';
 
   @override

--- a/lib/screens/app_settings_screen.dart
+++ b/lib/screens/app_settings_screen.dart
@@ -688,6 +688,10 @@ class AppSettingsScreen extends StatelessWidget {
               value: 'lipo',
               child: Text(context.l10n.appSettings_batteryLipo),
             ),
+            DropdownMenuItem(
+              value: 'lipo_hv',
+              child: Text(context.l10n.appSettings_batteryLipoHv),
+            ),
           ],
         ),
       ],
@@ -1153,9 +1157,7 @@ class AppSettingsScreen extends StatelessWidget {
   ) {
     final currentApiKey = settingsService.settings.mapTileApiKey?.trim() ?? '';
     final maskedApiKey = _maskApiKey(
-      currentApiKey.isEmpty
-          ? AppSettings.stadiaDemo
-          : currentApiKey,
+      currentApiKey.isEmpty ? AppSettings.stadiaDemo : currentApiKey,
     );
     final controller = TextEditingController(text: maskedApiKey);
     showDialog(

--- a/lib/screens/repeater_hub_screen.dart
+++ b/lib/screens/repeater_hub_screen.dart
@@ -165,6 +165,10 @@ class RepeaterHubScreen extends StatelessWidget {
                       value: 'lipo',
                       child: Text(l10n.appSettings_batteryLipo),
                     ),
+                    DropdownMenuItem(
+                      value: 'lipo_hv',
+                      child: Text(l10n.appSettings_batteryLipoHv),
+                    ),
                   ],
                 ),
               ),

--- a/lib/utils/battery_utils.dart
+++ b/lib/utils/battery_utils.dart
@@ -6,6 +6,8 @@ BatteryVoltageRange batteryVoltageRange(String chemistry) {
       return (minMv: 2600, maxMv: 3650);
     case 'lipo':
       return (minMv: 3000, maxMv: 4200);
+    case 'lipo_hv':
+      return (minMv: 3000, maxMv: 4350);
     case 'nmc':
     default:
       return (minMv: 3000, maxMv: 4200);


### PR DESCRIPTION
## Summary

Adds a LiPo HV (3.0-4.35V) battery chemistry option to both chemistry pickers (per device and per repeater). High voltage cells rest around 4.3V at full charge, for example the Seeed SenseCAP MeshTracker X1 ships one, and with the existing 4.2V ceiling the battery gauge pins at 100 percent for the whole top of the discharge curve.

One new localization key following the existing battery label pattern.

## Testing

Compile verified on all five platform targets in CI with the analyze and format gates passing, and running installed on a test device. The X1 hardware referenced reads 4.30V at rest when full, which the new range maps to 100 percent instead of overflow.
