### PR TITLE
docs: clarify third-party location data sharing

### DIFF
--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -51,7 +51,7 @@ Required by Android for BLE scanning on Android 11 and below. MeshCore Open does
 ### Internet Permission
 - **INTERNET**
 
-Used for features that access third-party internet services, including map tiles, Line-of-Sight elevation lookups, and optional GIF search.
+Used for features that access third-party internet services, including map tiles, Line-of-Sight elevation lookups, optional model downloads, and optional GIF search.
 
 ### Notification Permission
 - **POST_NOTIFICATIONS** (Android 13+)
@@ -76,6 +76,13 @@ When you use the Line-of-Sight (LOS) analysis feature, the App sends latitude an
 Open-Meteo uses these coordinates to return terrain elevation data needed for the LOS calculation. The request also exposes your device's IP address to Open-Meteo as part of normal internet communication.
 
 LOS elevation lookups are only made when the LOS feature is used. See [Open-Meteo's Terms and Privacy information](https://open-meteo.com/en/terms) for more information.
+
+### Model Downloads (Hugging Face)
+The App can download optional translation models and the optional neural image-codec model bundle from Hugging Face when you choose to install or update those models in Settings.
+
+When a model download is requested, the App sends standard HTTP requests for the selected model files to `huggingface.co`. Your device's IP address is visible to Hugging Face as part of normal internet communication. The App does not upload your messages, contacts, mesh location data, or other locally stored content to Hugging Face as part of these model downloads.
+
+Model-download requests are only made when you choose to download or update a model. See [Hugging Face's Privacy Policy](https://huggingface.co/privacy) for more information.
 
 ### GIF Search (Giphy)
 The App includes a GIF picker feature powered by Giphy. When you use the GIF search feature:
@@ -111,4 +118,4 @@ If you have questions about this Privacy Policy or the App's privacy practices, 
 
 ---
 
-**Summary**: MeshCore Open does not use the phone's GPS for location, does not include analytics, and does not collect personal information for the developer. Some optional features communicate with third-party services, including map tile providers, Open-Meteo for LOS elevation lookups, and Giphy for GIF search.
+**Summary**: MeshCore Open does not use the phone's GPS for location, does not include analytics, and does not collect personal information for the developer. Some optional features communicate with third-party services, including map tile providers, Open-Meteo for LOS elevation lookups, Hugging Face for model downloads, and Giphy for GIF search.

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for MeshCore Open
 
-**Last Updated:** January 11, 2026
+**Last Updated:** August 23, 2026
 
 ## Introduction
 
@@ -11,16 +11,17 @@ MeshCore Open ("the App") is an open-source Flutter application for communicatin
 ### Data We Do NOT Collect
 
 MeshCore Open does **not**:
-- Collect personal information
-- Send data to external servers (except map tile requests)
+- Collect personal information for the developer
 - Track your usage or behavior
 - Use analytics services
 - Require account creation
-- Share any data with third parties
+- Sell personal information
+
+The App does make limited requests to third-party services when you use features that require internet access, as described below.
 
 ### Data Stored Locally on Your Device
 
-The App stores the following data **locally on your device only**:
+The App stores the following data **locally on your device**:
 
 - **Messages**: Chat messages sent and received through the mesh network
 - **Contacts**: Names and identifiers of mesh network contacts
@@ -30,7 +31,7 @@ The App stores the following data **locally on your device only**:
 - **Debug Logs**: Optional BLE and app debug logs (if enabled by user)
 - **Cached Map Tiles**: Offline map data for the mapping feature
 
-All locally stored data remains on your device and is never transmitted to us or any third party.
+This locally stored data is not transmitted to the MeshCore Open developer. Some features may send specific data to third-party services as described in the Third-Party Services section.
 
 ## Permissions
 
@@ -45,12 +46,12 @@ These permissions are used solely to discover and communicate with MeshCore hard
 ### Location Permission
 - **ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION**
 
-Required by Android for BLE scanning on Android 11 and below. The App does not track or store your location. Location data may be optionally shared over the mesh network if you choose to enable location sharing features.
+Required by Android for BLE scanning on Android 11 and below. MeshCore Open does not use the phone's GPS to determine your location. Location data shown in the App comes from MeshCore devices and mesh advertisements. Location data may also be optionally shared over the mesh network if you choose to enable location sharing features.
 
 ### Internet Permission
 - **INTERNET**
 
-Used only for downloading map tiles from OpenStreetMap tile servers when using the map feature. No personal data is transmitted.
+Used for features that access third-party internet services, including map tiles, Line-of-Sight elevation lookups, and optional GIF search.
 
 ### Notification Permission
 - **POST_NOTIFICATIONS** (Android 13+)
@@ -65,7 +66,16 @@ Used to maintain BLE connection with your MeshCore device while the app is in th
 ## Third-Party Services
 
 ### Map Tiles
-The App uses OpenStreetMap tile servers to display maps. When viewing maps, your device's IP address may be visible to the tile server. No other data is shared. See [OpenStreetMap's Privacy Policy](https://wiki.osmfoundation.org/wiki/Privacy_Policy) for more information.
+The App uses OpenStreetMap and, when selected in settings, Stadia Maps tile servers to display maps. Map tile requests include tile coordinates that identify the geographic area being viewed, and your device's IP address may be visible to the tile provider.
+
+See [OpenStreetMap's Privacy Policy](https://wiki.osmfoundation.org/wiki/Privacy_Policy) and [Stadia Maps' Privacy Policy](https://stadiamaps.com/privacy/) for more information.
+
+### Line-of-Sight Elevation Lookups (Open-Meteo)
+When you use the Line-of-Sight (LOS) analysis feature, the App sends latitude and longitude coordinates for points along the selected radio path to the Open-Meteo Elevation API. These coordinates come from MeshCore node positions or locations selected in the map, not from the phone's GPS.
+
+Open-Meteo uses these coordinates to return terrain elevation data needed for the LOS calculation. The request also exposes your device's IP address to Open-Meteo as part of normal internet communication.
+
+LOS elevation lookups are only made when the LOS feature is used. See [Open-Meteo's Terms and Privacy information](https://open-meteo.com/en/terms) for more information.
 
 ### GIF Search (Giphy)
 The App includes a GIF picker feature powered by Giphy. When you use the GIF search feature:
@@ -81,7 +91,7 @@ Messages sent through the MeshCore mesh network are transmitted over radio frequ
 
 ## Data Security
 
-All data is stored locally on your device using standard Flutter/Android storage mechanisms. The App does not implement additional encryption for locally stored data beyond what the operating system provides.
+All data stored locally on your device uses standard Flutter/Android storage mechanisms. The App does not implement additional encryption for locally stored data beyond what the operating system provides.
 
 ## Children's Privacy
 
@@ -101,4 +111,4 @@ If you have questions about this Privacy Policy or the App's privacy practices, 
 
 ---
 
-**Summary**: MeshCore Open is a privacy-respecting app that stores all data locally on your device. We do not collect, track, or share your personal information.
+**Summary**: MeshCore Open does not use the phone's GPS for location, does not include analytics, and does not collect personal information for the developer. Some optional features communicate with third-party services, including map tile providers, Open-Meteo for LOS elevation lookups, and Giphy for GIF search.


### PR DESCRIPTION
## Summary

Updates the privacy policy to accurately describe location-related third-party requests made by the app.

- Clarifies that Android fine/coarse location permissions are used for BLE compatibility on Android 11 and below.
- States that MeshCore Open does not use the phone's GPS for location.
- Documents Open-Meteo LOS elevation requests, including that mesh/map coordinates are sent to the elevation API.
- Documents OpenStreetMap and Stadia Maps tile requests and the geographic information exposed by tile coordinates.
- Updates the INTERNET permission description to include map tiles, LOS elevation lookups, and optional GIF search.
- Removes conflicting claims that no data is ever shared with third parties.

This brings the policy in line with the current implementation and the Google Play Data Safety disclosure.