### PR TITLE
Handle MeshCoreOne's emoji reactions

### DIFF
--- a/lib/connector/meshcore_connector.dart
+++ b/lib/connector/meshcore_connector.dart
@@ -3563,27 +3563,31 @@ class MeshCoreConnector extends ChangeNotifier {
 
       // Process reaction locally to update the UI immediately
       appLogger.info('Adding sent channel reaction, id: $reactionIdentifier');
-      _processReaction(messages, reactionInfo);
-      await _channelMessageStore.saveChannelMessages(channel.index, messages);
+      final reactionApplied = _processReaction(messages, reactionInfo);
+      if (reactionApplied) {
+        await _channelMessageStore.saveChannelMessages(channel.index, messages);
 
-      // Mark this reaction as processed
-      _processedChannelReactions[channel.index]!.add(reactionIdentifier);
+        // Mark this reaction as processed
+        _processedChannelReactions[channel.index]!.add(reactionIdentifier);
 
-      notifyListeners();
+        notifyListeners();
 
-      // Send the reaction to the device (don't add as a visible message)
-      final reactionQueueId = _nextReactionSendQueueId();
-      _pendingChannelSentQueue.add(reactionQueueId);
-      await _runScopedChannelSend(() async {
-        await _waitForRadioQuiet(lastInboundRxTime: _lastChannelMsgRxTime);
-        await _sendFrameAndWaitForCommandAck(
-          buildSendChannelTextMsgFrame(channel.index, text),
-          channelSendQueueId: reactionQueueId,
-          expectsGenericAck: true,
-          successCode: respCodeSent,
-        );
-      }, region: getChannelRegion(channel.index));
-      return;
+        // Send the reaction to the device (don't add as a visible message)
+        final reactionQueueId = _nextReactionSendQueueId();
+        _pendingChannelSentQueue.add(reactionQueueId);
+        await _runScopedChannelSend(() async {
+          await _waitForRadioQuiet(lastInboundRxTime: _lastChannelMsgRxTime);
+          await _sendFrameAndWaitForCommandAck(
+            buildSendChannelTextMsgFrame(channel.index, text),
+            channelSendQueueId: reactionQueueId,
+            expectsGenericAck: true,
+            successCode: respCodeSent,
+          );
+        }, region: getChannelRegion(channel.index));
+        return;
+      }
+      // It looks like a reaction, but we did not find its target, so
+      // we continue to process it normally.
     }
 
     final message = ChannelMessage.outgoing(
@@ -6227,27 +6231,39 @@ class MeshCoreConnector extends ChangeNotifier {
       final isDuplicate = _processedContactReactions[pubKeyHex]!.contains(
         reactionIdentifier,
       );
+      if (isDuplicate) return;
 
-      if (!isDuplicate) {
-        // New reaction - process it
+      // New reaction - process it
+      // For hashing and dup checking, we use null for sender names in
+      // normal 1:1 chats. This way if we and they have different ideas
+      // about what their name is, reactions still work. But for reaction
+      // reports, we want to know who sent what, rather than infer it later,
+      // so we'll add it to the reactionInfo before storing it.
+      reactionInfo.senderName ??= message.isOutgoing
+          ? selfName
+          : getContactByPubKeyHex(pubKeyHex)?.name ?? '???';
+      final reactionApplied = _processContactReaction(
+        messages,
+        reactionInfo,
+        pubKeyHex,
+      );
+      if (reactionApplied) {
         appLogger.info('Adding reaction, id: $reactionIdentifier');
-        // For hashing and dup checking, we use null for sender names in
-        // normal 1:1 chats. This way if we and they have different ideas
-        // about what their name is, reactions still work. But for reaction
-        // reports, we want to know who sent what, rather than infer it later,
-        // so we'll add it to the reactionInfo before storing it.
-        reactionInfo.senderName ??= message.isOutgoing
-            ? selfName
-            : getContactByPubKeyHex(pubKeyHex)?.name ?? '???';
-        _processContactReaction(messages, reactionInfo, pubKeyHex);
         _messageStore.saveMessages(pubKeyHex, messages);
 
         // Mark as processed
         _processedContactReactions[pubKeyHex]!.add(reactionIdentifier);
 
         notifyListeners();
+        return; // Don't add reaction as a visible message
       }
-      return; // Don't add reaction as a visible message
+
+      // Looks like a reaction, but didn't match any message we have.
+      // for reactions matching our own format, because those are not very
+      // informative on their own, but the MC1 format is useful even if
+      // in raw form, so we'll let those through.
+      appLogger.info('No match for reaction, id: $reactionIdentifier');
+      if (reactionInfo.hashType == HashType.ours) return;
     }
 
     messages.add(message);
@@ -6258,7 +6274,7 @@ class MeshCoreConnector extends ChangeNotifier {
     notifyListeners();
   }
 
-  void _processContactReaction(
+  bool _processContactReaction(
     List<Message> messages,
     ReactionInfo reactionInfo,
     String contactPubKeyHex,
@@ -6266,7 +6282,7 @@ class MeshCoreConnector extends ChangeNotifier {
     final contact = getContactByPubKeyHex(contactPubKeyHex);
     final isRoomServer = contact?.type == advTypeRoom;
 
-    ReactionHelper.applyReaction<Message>(
+    return ReactionHelper.applyReaction<Message>(
       messages: messages,
       reactionInfo: reactionInfo,
       // Incoming reactions in 1:1: match against outgoing messages only
@@ -6481,17 +6497,26 @@ class MeshCoreConnector extends ChangeNotifier {
         reactionIdentifier,
       );
 
-      if (!isDuplicate) {
-        // New reaction - process it
+      if (isDuplicate) return false;
+
+      // New reaction - process it
+      final reactionApplied = _processReaction(messages, reactionInfo);
+      if (reactionApplied) {
         appLogger.info('Adding channel reaction, id: $reactionIdentifier');
-        _processReaction(messages, reactionInfo);
         // Save updated messages
         _channelMessageStore.saveChannelMessages(channelIndex, messages);
 
         // Mark as processed
         _processedChannelReactions[channelIndex]!.add(reactionIdentifier);
+        return false; // Don't add reaction as a visible message
       }
-      return false; // Don't add reaction as a visible message
+      // Looks like a reaction, but didn't match any message we have.
+      // Old behavior is to silently drop these. We'll continue doing that
+      // for reactions matching our own format, because those are not very
+      // informative on their own, but the MC1 format is useful even if
+      // in raw form, so we'll let those through.
+      appLogger.info('No match for reaction, id: $reactionIdentifier');
+      if (reactionInfo.hashType == HashType.ours) return false;
     }
 
     // Parse reply info from message text
@@ -6593,11 +6618,11 @@ class MeshCoreConnector extends ChangeNotifier {
     return null;
   }
 
-  void _processReaction(
+  bool _processReaction(
     List<ChannelMessage> messages,
     ReactionInfo reactionInfo,
   ) {
-    ReactionHelper.applyReaction<ChannelMessage>(
+    return ReactionHelper.applyReaction<ChannelMessage>(
       messages: messages,
       reactionInfo: reactionInfo,
       shouldSkip: (_) => false,

--- a/lib/helpers/reaction_helper.dart
+++ b/lib/helpers/reaction_helper.dart
@@ -1,13 +1,22 @@
+import 'dart:typed_data';
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
+import 'package:base32/base32.dart';
+import 'package:base32/encodings.dart';
 import '../widgets/emoji_picker.dart';
+
+enum HashType { ours, mc1 }
 
 class ReactionInfo {
   final String targetHash;
   final String emoji;
-  String? senderName;
+  HashType hashType;
+  String? senderName; // Who sent the reaction
 
   ReactionInfo({
     required this.targetHash,
     required this.emoji,
+    required this.hashType,
     this.senderName,
   });
 
@@ -40,11 +49,18 @@ class ReactionHelper {
     updateMessage,
   }) {
     final targetHash = reactionInfo.targetHash;
+    final hashFunc = switch (reactionInfo.hashType) {
+      HashType.ours => computeReactionHash,
+      HashType.mc1 => ((ts, senderName, text) => _concatenateHashAndSender(
+        computeReactionHashMC1(ts, senderName, text),
+        senderName,
+      )),
+    };
     for (int i = messages.length - 1; i >= 0; i--) {
       final msg = messages[i];
       if (shouldSkip(msg)) continue;
 
-      final msgHash = computeReactionHash(
+      final msgHash = hashFunc(
         getTimestampSecs(msg),
         getSenderName(msg),
         getMessageText(msg),
@@ -108,17 +124,72 @@ class ReactionHelper {
     return hash.toRadixString(16).padLeft(4, '0');
   }
 
+  // Compute the type of reaction hash used by MeshCoreOne.
+  static String computeReactionHashMC1(
+    int timestampSeconds,
+    String? senderName,
+    String messageText,
+  ) {
+    // TODO: unit tests
+    // raw hash is first 5 bytes of SHA-256(UTF-8 text + uint32-LE sender timestamp)
+    Uint8List messageBytes = utf8.encode(messageText);
+    ByteData timestampBytes = ByteData(4)
+      ..setUint32(0, timestampSeconds, Endian.little);
+    final hash = sha256
+        .convert(messageBytes + timestampBytes.buffer.asUint8List())
+        .bytes
+        .sublist(0, 5);
+
+    // encode as 8 chars of Crockford base32
+    return base32
+        .encode(Uint8List.fromList(hash), encoding: Encoding.crockford)
+        .toLowerCase();
+  }
+
+  // MeshCoreOne-style reaction hashes don't depend on the sender name,
+  // and we're expected to check the hash and sender name separately.
+  // Our own reaction hashes include it. Rather than store the sender
+  // Name in ReactionInfo and complicate the logic in applyReaction(),
+  // we just tack the senderName onto the end of the "hash".
+  static String _concatenateHashAndSender(String hash, String? senderName) {
+    return "$hash:${senderName ?? ''}";
+  }
+
+  static ReactionInfo? parseReaction(String text) {
+    return parseReactionOurs(text) ?? parseReactionMC1(text);
+  }
+
+  static ReactionInfo? parseReactionMC1(String text) {
+    // See https://github.com/Avi0n/MeshCoreOne/blob/main/docs/Reactions.md
+    // This regex matches both the channel format, which includes the sender name,
+    // and the chat (DM) format, which omits it.
+    final regex = RegExp(r'^(.{1,4})(?:@\[(.*)])?\n([a-zA-Z0-9]{8})$');
+    final match = regex.firstMatch(text);
+    if (match == null) return null;
+
+    final hash = match.group(3)?.toLowerCase();
+    final senderName = match.group(2);
+    return ReactionInfo(
+      targetHash: _concatenateHashAndSender(hash!, senderName),
+      emoji: match.group(1)!,
+      hashType: HashType.mc1,
+    );
+  }
+
   /// Parse reaction format: r:HASH:INDEX (where INDEX is 2-char hex emoji index)
   /// Returns null if text is not a valid reaction format
-  static ReactionInfo? parseReaction(String text) {
+  static ReactionInfo? parseReactionOurs(String text) {
     final regex = RegExp(r'^r:([0-9a-f]{4}):([0-9a-f]{2})$');
     final match = regex.firstMatch(text);
     if (match == null) return null;
 
     final emoji = indexToEmoji(match.group(2)!);
     if (emoji == null) return null;
-
-    return ReactionInfo(targetHash: match.group(1)!, emoji: emoji);
+    return ReactionInfo(
+      targetHash: match.group(1)!,
+      emoji: emoji,
+      hashType: HashType.ours,
+    );
   }
 
   /// Encode a reaction message that parseReaction() can parse.

--- a/lib/helpers/reaction_helper.dart
+++ b/lib/helpers/reaction_helper.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'dart:convert';
+import 'package:characters/characters.dart';
 import 'package:crypto/crypto.dart';
 import 'package:base32/base32.dart';
 import 'package:base32/encodings.dart';
@@ -21,7 +22,7 @@ class ReactionInfo {
   });
 
   String identifier() {
-    return '$targetHash:$emoji:${senderName ?? ""}';
+    return '$targetHash:$emoji:$hashType:${senderName ?? ""}';
   }
 }
 
@@ -130,7 +131,6 @@ class ReactionHelper {
     String? senderName,
     String messageText,
   ) {
-    // TODO: unit tests
     // raw hash is first 5 bytes of SHA-256(UTF-8 text + uint32-LE sender timestamp)
     Uint8List messageBytes = utf8.encode(messageText);
     ByteData timestampBytes = ByteData(4)
@@ -144,6 +144,11 @@ class ReactionHelper {
     return base32
         .encode(Uint8List.fromList(hash), encoding: Encoding.crockford)
         .toLowerCase();
+    // Note: Crockford32 defines permissive decoding and allows some
+    // substitutions (e.g. I, i, l -> 1) but we never decode the hashes, we
+    // just compare them. If someone sends a miscoded hash that should be
+    // equivalent, we won't match it and it won't work. But it's not worth
+    // accommodating, because no one is going to be hand copying hashes.
   }
 
   // MeshCoreOne-style reaction hashes don't depend on the sender name,
@@ -159,19 +164,43 @@ class ReactionHelper {
     return parseReactionOurs(text) ?? parseReactionMC1(text);
   }
 
+  static bool _looksLikeEmoji(String emoji) {
+    // Make sure it's a single grapheme.
+    if (Characters(emoji).length > 1) return false;
+
+    // Below are some emoji-validating tests, copied from MeshTrax.
+    // https://github.com/venamartin/meshtrax/
+    // It's nice to avoid false positives just to save us some processing,
+    // but it's not crucial, as we will either apply a reaction or show it
+    // as a message. Text that is not actually a hash is unlikely to match
+    // a message.
+    if (emoji.isEmpty) return false;
+    // Emoji, not prose: nearly all emoji start at U+2000 or above; the
+    // exceptions (keycaps, ©/®) carry a variation selector U+FE0F or a
+    // combining keycap U+20E3. Ordinary ASCII text fails both tests.
+    if (!(emoji.runes.first >= 0x2000 ||
+        emoji.runes.any((r) => r == 0xFE0F || r == 0x20E3))) {
+      return false;
+    }
+    return true;
+  }
+
   static ReactionInfo? parseReactionMC1(String text) {
     // See https://github.com/Avi0n/MeshCoreOne/blob/main/docs/Reactions.md
     // This regex matches both the channel format, which includes the sender name,
     // and the chat (DM) format, which omits it.
-    final regex = RegExp(r'^(.{1,4})(?:@\[(.*)])?\n([a-zA-Z0-9]{8})$');
+    final regex = RegExp(r'^(.+?)(?:@\[(.*)])?\n([a-tv-zA-TV-Z0-9]{8})$');
     final match = regex.firstMatch(text);
     if (match == null) return null;
 
     final hash = match.group(3)?.toLowerCase();
     final senderName = match.group(2);
+    final emoji = match.group(1)!;
+    if (!_looksLikeEmoji(emoji)) return null;
+
     return ReactionInfo(
       targetHash: _concatenateHashAndSender(hash!, senderName),
-      emoji: match.group(1)!,
+      emoji: emoji,
       hashType: HashType.mc1,
     );
   }

--- a/lib/helpers/reaction_helper.dart
+++ b/lib/helpers/reaction_helper.dart
@@ -161,7 +161,9 @@ class ReactionHelper {
   }
 
   static ReactionInfo? parseReaction(String text) {
-    return parseReactionOurs(text) ?? parseReactionMC1(text);
+    return parseReactionOurs(text) ??
+        parseReactionMC1(text) ??
+        parseReactionMC1Legacy(text);
   }
 
   static bool _looksLikeEmoji(String emoji) {
@@ -186,6 +188,26 @@ class ReactionHelper {
   }
 
   static ReactionInfo? parseReactionMC1(String text) {
+    // See https://github.com/Avi0n/MeshCoreOne/blob/main/docs/Reactions.md
+    // This regex matches both the channel format, which includes the sender name,
+    // and the chat (DM) format, which omits it.
+    final regex = RegExp(r'^(?:@\[(.*)])?(.+?)\n([a-tv-zA-TV-Z0-9]{8})$');
+    final match = regex.firstMatch(text);
+    if (match == null) return null;
+
+    final senderName = match.group(1);
+    final emoji = match.group(2)!;
+    final hash = match.group(3)?.toLowerCase();
+    if (!_looksLikeEmoji(emoji)) return null;
+
+    return ReactionInfo(
+      targetHash: _concatenateHashAndSender(hash!, senderName),
+      emoji: emoji,
+      hashType: HashType.mc1,
+    );
+  }
+
+  static ReactionInfo? parseReactionMC1Legacy(String text) {
     // See https://github.com/Avi0n/MeshCoreOne/blob/main/docs/Reactions.md
     // This regex matches both the channel format, which includes the sender name,
     // and the chat (DM) format, which omits it.

--- a/lib/models/channel_message.dart
+++ b/lib/models/channel_message.dart
@@ -318,7 +318,12 @@ class ChannelMessage {
       final emoji = entry.key;
       for (final senderName in entry.value) {
         reactionList.add(
-          ReactionInfo(targetHash: hash, emoji: emoji, senderName: senderName),
+          ReactionInfo(
+            targetHash: hash, // won't be used for anything
+            emoji: emoji,
+            senderName: senderName,
+            hashType: HashType.ours, // also not used for anything
+          ),
         );
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   # the abiFilters note in android/app/build.gradle.kts; a universal APK pays
   # ~56 MB for ORT instead of ~18 MB.
   flutter_onnxruntime: ^1.8.3
+  base32: ^2.2.0
 
 hooks:
   user_defines:

--- a/test/reaction_helper_test.dart
+++ b/test/reaction_helper_test.dart
@@ -340,6 +340,64 @@ void main() {
       });
     });
 
+    group('MeshCoreOne Reactions', () {
+      test('regex for matching emoji char', () {
+        // This is more a test of expectations than of app code, but it was
+        // a good place to get this sorted out cleanly, and I leave it for
+        // anyone interested in understanding the regex in the parsing.
+        final regex = RegExp(r'^(.{1,4})$');
+        expect(regex.firstMatch('🥳'), isNotNull);
+        expect(regex.firstMatch('😀'), isNotNull);
+        expect(regex.firstMatch('\u{1F642}'), isNotNull);
+        expect(regex.firstMatch('\u{1f44c}\u{1f3ff}'), isNotNull);
+      });
+
+      test('parse MeshCoreOne reaction', () {
+        final emoji = '🥳';
+        final senderName = 'entropy 📓';
+        final hash = 'b3je6qf7';
+        final info = ReactionHelper.parseReactionMC1(
+          '$emoji@[$senderName]\n$hash',
+        );
+        expect(info, isNotNull);
+        expect(info!.targetHash, equals('$hash:$senderName'));
+        expect(info.emoji, equals(emoji));
+      });
+
+      test('parse MeshCoreOne reaction - main entry', () {
+        final emoji = '🥳';
+        final senderName = 'entropy 📓';
+        final hash = 'b3je6qf7';
+        final info = ReactionHelper.parseReaction(
+          '$emoji@[$senderName]\n$hash',
+        );
+        expect(info, isNotNull);
+        expect(info!.targetHash, equals('$hash:$senderName'));
+        expect(info.emoji, equals(emoji));
+      });
+
+      test('parse MeshCoreOne reaction for DM chats', () {
+        final emoji = '🥳';
+        final hash = 'b3je6qf7';
+        final info = ReactionHelper.parseReaction('$emoji\n$hash');
+        expect(info, isNotNull);
+        expect(info!.targetHash, equals('$hash:'));
+        expect(info.emoji, equals(emoji));
+      });
+
+      test('compute MeshCoreOne reaction hash', () {
+        const timestamp = 1234567890;
+        const senderName = 'Alice';
+        const messageText = 'Hello world!';
+        final hash = ReactionHelper.computeReactionHashMC1(
+          timestamp,
+          senderName,
+          messageText,
+        );
+        expect(hash, equals('tyvbkb33'));
+      });
+    });
+
     group('full reaction flow', () {
       test('should encode and decode reaction correctly', () {
         // Simulate sending a reaction

--- a/test/reaction_helper_test.dart
+++ b/test/reaction_helper_test.dart
@@ -1,3 +1,4 @@
+import 'package:characters/characters.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meshcore_open/helpers/reaction_helper.dart';
 import 'package:meshcore_open/widgets/emoji_picker.dart';
@@ -341,15 +342,30 @@ void main() {
     });
 
     group('MeshCoreOne Reactions', () {
-      test('regex for matching emoji char', () {
+      test('emoji validation sanity checks', () {
         // This is more a test of expectations than of app code, but it was
         // a good place to get this sorted out cleanly, and I leave it for
-        // anyone interested in understanding the regex in the parsing.
+        // anyone interested in understanding the emoji validation and tests.
+        expect('🥳'.length, equals(2));
+        expect('\u{1f44c}\u{1f3ff}'.length, equals(4));
+        final oneChar = RegExp(r'^(.)$');
+        final twoChar = RegExp(r'^(..)$');
+        expect(oneChar.firstMatch('🥳'), isNull);
+        expect(oneChar.firstMatch('\u{1F642}'), isNull);
+        expect(oneChar.firstMatch('\u{1f44c}\u{1f3ff}'), isNull);
+        expect(twoChar.firstMatch('\u{1f44c}\u{1f3ff}'), isNull);
+
         final regex = RegExp(r'^(.{1,4})$');
         expect(regex.firstMatch('🥳'), isNotNull);
         expect(regex.firstMatch('😀'), isNotNull);
         expect(regex.firstMatch('\u{1F642}'), isNotNull);
         expect(regex.firstMatch('\u{1f44c}\u{1f3ff}'), isNotNull);
+
+        expect(Characters('🥳').length, equals(1));
+        expect(Characters('\u{1F642}').length, equals(1));
+        expect(Characters('\u{1F642}').length, equals(1));
+        expect(Characters('\u{1f44c}\u{1f3ff}').length, equals(1));
+        expect(Characters('🧑‍🧑‍🧒‍🧒').length, equals(1));
       });
 
       test('parse MeshCoreOne reaction', () {
@@ -362,6 +378,34 @@ void main() {
         expect(info, isNotNull);
         expect(info!.targetHash, equals('$hash:$senderName'));
         expect(info.emoji, equals(emoji));
+
+        List<String> messages = [
+          '🥳\n01234567',
+          '🥳@[entropy]\n01234567',
+          '\u{1f44c}\u{1f3ff}\n01234567',
+          '\u{1f44c}\u{1f3ff}@[entropy]\n01234567',
+          '🧑‍🧑‍🧒@[entropy]\n01234567', // long composite emoji - 21 bytes
+          '🧑‍🧑‍🧒‍🧒\n01234567', // long composite emoji - 25 bytes
+        ];
+        for (String txt in messages) {
+          final info = ReactionHelper.parseReactionMC1(txt);
+          expect(info, isNotNull, reason: "$txt did not parse");
+        }
+      });
+
+      test('parse MeshCoreOne reaction - avoid false positives', () {
+        List<String> messages = [
+          'test\nabcdefgh',
+          '🥳\nhashistoolong',
+          '🥳\nshort',
+          '🥳🥳\n01234567', // two emojis not composed into one grapheme
+          'X\n01234567',
+          '🥳\nabcuuxyz', // u is not valid as we don't support checksums
+        ];
+        for (String txt in messages) {
+          final info = ReactionHelper.parseReactionMC1(txt);
+          expect(info, isNull, reason: "$txt should not have parsed");
+        }
       });
 
       test('parse MeshCoreOne reaction - main entry', () {
@@ -385,7 +429,7 @@ void main() {
         expect(info.emoji, equals(emoji));
       });
 
-      test('compute MeshCoreOne reaction hash', () {
+      test('computeq MeshCoreOne reaction hash', () {
         const timestamp = 1234567890;
         const senderName = 'Alice';
         const messageText = 'Hello world!';

--- a/test/reaction_helper_test.dart
+++ b/test/reaction_helper_test.dart
@@ -373,7 +373,7 @@ void main() {
         final senderName = 'entropy 📓';
         final hash = 'b3je6qf7';
         final info = ReactionHelper.parseReactionMC1(
-          '$emoji@[$senderName]\n$hash',
+          '@[$senderName]$emoji\n$hash',
         );
         expect(info, isNotNull);
         expect(info!.targetHash, equals('$hash:$senderName'));
@@ -381,10 +381,10 @@ void main() {
 
         List<String> messages = [
           '🥳\n01234567',
-          '🥳@[entropy]\n01234567',
+          '@[entropy]🥳\n01234567',
           '\u{1f44c}\u{1f3ff}\n01234567',
-          '\u{1f44c}\u{1f3ff}@[entropy]\n01234567',
-          '🧑‍🧑‍🧒@[entropy]\n01234567', // long composite emoji - 21 bytes
+          '@[entropy]\u{1f44c}\u{1f3ff}\n01234567',
+          '@[entropy]🧑‍🧑‍🧒\n01234567', // long composite emoji - 21 bytes
           '🧑‍🧑‍🧒‍🧒\n01234567', // long composite emoji - 25 bytes
         ];
         for (String txt in messages) {
@@ -408,7 +408,62 @@ void main() {
         }
       });
 
+      test('parse MeshCoreOne reaction - Legacy format', () {
+        final emoji = '🥳';
+        final senderName = 'entropy 📓';
+        final hash = 'b3je6qf7';
+        final info = ReactionHelper.parseReactionMC1Legacy(
+          '$emoji@[$senderName]\n$hash',
+        );
+        expect(info, isNotNull);
+        expect(info!.targetHash, equals('$hash:$senderName'));
+        expect(info.emoji, equals(emoji));
+
+        List<String> messages = [
+          '🥳\n01234567',
+          '🥳@[entropy]\n01234567',
+          '\u{1f44c}\u{1f3ff}\n01234567',
+          '\u{1f44c}\u{1f3ff}@[entropy]\n01234567',
+          '🧑‍🧑‍🧒@[entropy]\n01234567', // long composite emoji - 21 bytes
+          '🧑‍🧑‍🧒‍🧒\n01234567', // long composite emoji - 25 bytes
+        ];
+        for (String txt in messages) {
+          final info = ReactionHelper.parseReactionMC1Legacy(txt);
+          expect(info, isNotNull, reason: "$txt did not parse");
+        }
+      });
+
+      test(
+        'parse MeshCoreOne reaction - Legacy format - avoid false positives',
+        () {
+          List<String> messages = [
+            'test\nabcdefgh',
+            '🥳\nhashistoolong',
+            '🥳\nshort',
+            '🥳🥳\n01234567', // two emojis not composed into one grapheme
+            'X\n01234567',
+            '🥳\nabcuuxyz', // u is not valid as we don't support checksums
+          ];
+          for (String txt in messages) {
+            final info = ReactionHelper.parseReactionMC1Legacy(txt);
+            expect(info, isNull, reason: "$txt should not have parsed");
+          }
+        },
+      );
+
       test('parse MeshCoreOne reaction - main entry', () {
+        final emoji = '🥳';
+        final senderName = 'entropy 📓';
+        final hash = 'b3je6qf7';
+        final info = ReactionHelper.parseReaction(
+          '@[$senderName]$emoji\n$hash',
+        );
+        expect(info, isNotNull);
+        expect(info!.targetHash, equals('$hash:$senderName'));
+        expect(info.emoji, equals(emoji));
+      });
+
+      test('parse MeshCoreOne reaction Legacy format - main entry', () {
         final emoji = '🥳';
         final senderName = 'entropy 📓';
         final hash = 'b3je6qf7';


### PR DESCRIPTION
MeshCoreOne is a companion app that supports emoji reactions, using a different message format than ours.

This commit adds support for parsing and displaying reactions received in the MeshCoreOne format.

Their format is described here:
 https://github.com/Avi0n/MeshCoreOne/blob/main/docs/Reactions.md

Here's an example:

👍@[entropy]
b3je6qf7

Major differences compared to MeshCore-Open's reaction messages:
- includes the emoji, rather than an index code
- includes the name of who sent the message it refers to
- the hash does not depend on the sender name

See #521.