### PR TITLE
Adding preset for Philly per latest blog post

### DIFF
--- a/lib/models/radio_settings.dart
+++ b/lib/models/radio_settings.dart
@@ -482,6 +482,16 @@ class RadioSettings {
       ),
     ),
     (
+      'USA Philly',
+      RadioSettings(
+        frequencyMHz: 902.250,
+        bandwidth: LoRaBandwidth.bw500,
+        spreadingFactor: LoRaSpreadingFactor.sf11,
+        codingRate: LoRaCodingRate.cr4_5,
+        txPowerDbm: 20,
+      ),
+    ),
+    (
       'USA/Canada',
       RadioSettings(
         frequencyMHz: 910.525,


### PR DESCRIPTION
Adding a USA Philly area preset as per the blog post here: https://phillymesh.net/2026/09/02/fcc-regulations/

902.250mhz, BW500, SF11.