### PR TITLE
flserial import points to MeshEnvy/PR1

### DIFF
--- a/lib/helpers/message_url_image_helper.dart
+++ b/lib/helpers/message_url_image_helper.dart
@@ -17,7 +17,7 @@ class MessageUrlImageHelper {
       LinkedHashMap<String, Future<String?>>();
 
   static final RegExp _pyxPattern = RegExp(
-    r'''https?://pyx\.li/\?i=([^\s<>'"`]+)''',
+    r'''https?://pyx\.li/\?i=([A-Za-z0-9_-]+)''',
     caseSensitive: false,
   );
 
@@ -57,10 +57,7 @@ class MessageUrlImageHelper {
 
     final pyxMatch = _pyxPattern.firstMatch(trimmed);
     if (pyxMatch != null) {
-      return _extractFromUrl(
-        _trimBoundary(pyxMatch.group(0)!),
-        RegExp(r'''<img[^>]+src=["']([^"']+)["']''', caseSensitive: false),
-      );
+      return 'https://pyx.li/i/${pyxMatch.group(1)!}.jpg';
     }
 
     final ipfsUrlMatch = _ipfsUrlPattern.firstMatch(trimmed);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   flserial:
     git:
       url: https://github.com/MeshEnvy/flserial.git
-      ref: 48216310061efc8d5d217cc18014fc2cb501646e
+      ref: e1864de9b65cda9656dba804329bdd2890dd5a92
   provider: ^6.1.5+1
   shared_preferences: ^2.2.2
   uuid: ^4.3.3


### PR DESCRIPTION
I updated pubspec.yaml to point the flserial to the commit of my PullRequest
[https://github.com/MeshEnvy/flserial/pull/1](https://github.com/MeshEnvy/flserial/pull/1)
which fixes the Issue https://github.com/zjs81/meshcore-open/issues/543 [Build (still) fails with once_flag.h:24:21: error](https://github.com/zjs81/meshcore-open/issues/543) on linux devices.

Used change to build Meshcore-open successfully on EndevourOS (aarch-linux based) and
for my build for Raspberry Pi 5 (arm build) via [.github/workflow](https://github.com/ericszimmermann/meshcore-open/blob/ez_RaspberryBuild/.github/workflows/raspberry_pi_5.yml)